### PR TITLE
Opencontainers labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Username used to log in to a Docker registry. If not set then no login will occu
 
 ### `password`
 
-Password used to log in to a Docker registry. If not set then no login will occur.
+Password or personal access token used to log in to a Docker registry. If not set then no login will occur.
 
 ### `registry`
 
@@ -131,8 +131,8 @@ The labels are:
 |Label key|Example value|Description|
 |---|---|---|
 |`org.opencontainers.image.created`|`2020-03-06T23:00:00Z`|Date and time on which the image was built (string, date-time as defined by RFC 3339).|
-|`org.opencontainers.image.source`|`https://github.com/myorg/myrepository`|URL to this repository.|
-|`org.opencontainers.image.revision`|`676cae2f85471aeff6776463c72881ebd902dcf9`|The full git sha of this commit.|
+|`org.opencontainers.image.source`|`https://github.com/myorg/myrepository`|URL to the GitHub repository.|
+|`org.opencontainers.image.revision`|`676cae2f85471aeff6776463c72881ebd902dcf9`|The full git SHA of this commit.|
 
 
 ### `push`

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: Username used to log in to a Docker registry. If not set then no login will occur
     required: false
   password:
-    description: Password used to log in to a Docker registry. If not set then no login will occur
+    description: Password or personal access token used to log in to a Docker registry. If not set then no login will occur
     required: false
   registry:
     description: Server address of Docker registry. If not set then will default to Docker Hub
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: false
   tag_with_sha:
-    description: Automatically tags the built image with the git short sha as per the readme
+    description: Automatically tags the built image with the git short SHA as per the readme
     required: false
     default: false
   path:


### PR DESCRIPTION
Setting the add_git_labels to true adds labels as per the
opencontainers standard: https://github.com/opencontainers/image-spec/blob/master/annotations.md

The 3 labels supported are:

* org.opencontainers.image.created
* org.opencontainers.image.source
* org.opencontainers.image.revision

This requires using a new version of the docker/github-actions image which has yet to be released. See https://github.com/docker/github-actions/pull/5