### PR TITLE
Add cache_froms input to support --cache-from

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Suggestions and issues can be posted on the repositories [issues page](https://g
 * [target](#target)
 * [always_pull](#always_pull)
 * [build_args](#build_args)
+* [cache_froms](#cache_froms)
 * [labels](#labels)
 * [add_git_labels](#add_git_labels)
 * [push](#push)
@@ -112,6 +113,15 @@ Example:
 
 ```yaml
 build_args: arg1=value1,arg2=value2
+```
+
+### `cache_froms`
+
+Comma-delimited list of images to consider as cache sources.
+
+Example:
+```yaml
+cache_froms: myorg/baseimage:latest
 ```
 
 ### `labels`

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   build_args:
     description: Comma-delimited list of build-time variables
     required: false
+  cache_froms:
+    description: Comma-delimited list of images to consider as cache sources
+    required: false
   labels:
     description: Comma-delimited list of labels to add to the built image
     required: false


### PR DESCRIPTION
Add `cache_froms` input to support the `--cache-from` command line argument for `docker build`.

This has been implemented in `docker/github-actions:v1.1.0` image (also tagged `v1`)