### PR TITLE
Demonstrate simple ref tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Examples:
 |Git Reference|Image tag|
 |---|---|
 |`refs/heads/master`|`latest`|
+|`refs/heads/mybranch`|`mybranch`|
 |`refs/heads/my/branch`|`my-branch`|
 |`refs/pull/2/merge`|`pr-2-merge`|
 |`refs/tags/v1.0.0`|`v1.0.0`|


### PR DESCRIPTION
Existing ref tag examples highlighted special cases, but none demonstrated the simplest branch case.

I wouldn't care, except I misread the documentation and wondered why my `master` branch only got tagged `latest`. Contrasting the `master`->`latest` mapping against a simple `mybranch`->`mybranch` example would very likely have caught my eye; with the more complicated transforms in the other examples, I missed that `master` was being completely replaced!

Yeah, I should read documentation more closely. I did, once I figured out my problem. But this is a simple change that would have caught a lazy reader like myself.