### PR TITLE
Add deprecation notice (v2 available)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ inputs:
     description: Server address of Docker registry. If not set then will default to Docker Hub
     required: false
   repository:
+    deprecationMessage: 'v2 beta is now available through docker/build-push-action@v2'
     description: Docker repository to tag the image with
     required: true
   tags:


### PR DESCRIPTION
I choose the `repository` input because it's the only required one and is not used in our v2.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>