### PR TITLE
Add Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
       -
         name: Test
         run: yarn run test
-#      -
-#        name: Upload coverage
-#        uses: codecov/codecov-action@v1.0.7
-#        if: success()
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          file: ./coverage/clover.xml
+      -
+        name: Upload coverage
+        uses: codecov/codecov-action@v1.0.7
+        if: success()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage/clover.xml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![GitHub marketplace](https://img.shields.io/badge/marketplace-docker--build--push-blue?logo=github&style=flat-square)](https://github.com/marketplace/actions/docker-build-push)
 [![CI workflow](https://img.shields.io/github/workflow/status/docker/build-push-action/ci?label=ci&logo=github&style=flat-square)](https://github.com/docker/build-push-action/actions?workflow=ci)
 [![Test workflow](https://img.shields.io/github/workflow/status/docker/build-push-action/test?label=test&logo=github&style=flat-square)](https://github.com/docker/build-push-action/actions?workflow=test)
+[![Codecov](https://img.shields.io/codecov/c/github/docker/build-push-action?logo=codecov&style=flat-square)](https://codecov.io/gh/docker/build-push-action)
 
 ## About
 


### PR DESCRIPTION
Can you [enable Codecov for this repo](https://codecov.io/gh/docker/build-push-action) and also [create the `CODECOV_TOKEN` secret](https://docs.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets-for-a-repository) to be able to upload coverage?

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>