### PR TITLE
Ensure --progress=plain to avoid logs cutting

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -64,7 +64,7 @@ export async function getArgs(inputs: Inputs, buildxVersion: string): Promise<Ar
 }
 
 async function getBuildArgs(inputs: Inputs, buildxVersion: string): Promise<Array<string>> {
-  let args: Array<string> = ['build'];
+  let args: Array<string> = ['build', '--progress', 'plain'];
   await asyncForEach(inputs.buildArgs, async buildArg => {
     args.push('--build-arg', buildArg);
   });


### PR DESCRIPTION
When run `docker buildx build --progress=plain` will got all logs (default: "auto").

`build-push-action` used in github workflow. i think this always could be set.