### PR TITLE
Labels and build args should not be handled as CSV type

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,44 +592,36 @@ with this action:
 
 Following inputs can be used as `step.with` keys
 
-| Name                | Type    | Description                        |
-|---------------------|---------|------------------------------------|
-| `builder`           | String  | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action) |
-| `context`           | String  | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context)) |
-| `file`              | String  | Path to the Dockerfile (default `Dockerfile`) |
-| `build-args`        | List    | List of build-time variables |
-| `labels`            | List    | List of metadata for an image |
-| `tags`              | List    | List of tags |
-| `pull`              | Bool    | Always attempt to pull a newer version of the image (default `false`) |
-| `target`            | String  | Sets the target stage to build |
-| `allow`             | List    | List of [extra privileged entitlement](https://github.com/docker/buildx#--allowentitlement) (eg. `network.host,security.insecure`) |
-| `no-cache`          | Bool    | Do not use cache when building the image (default `false`) |
-| `platforms`         | List    | List of [target platforms](https://github.com/docker/buildx#---platformvaluevalue) for build |
-| `load`              | Bool    | [Load](https://github.com/docker/buildx#--load) is a shorthand for `--output=type=docker` (default `false`) |
-| `push`              | Bool    | [Push](https://github.com/docker/buildx#--push) is a shorthand for `--output=type=registry` (default `false`) |
-| `outputs`           | CSV     | List of [output destinations](https://github.com/docker/buildx#-o---outputpath-typetypekeyvalue) (format: `type=local,dest=path`) |
-| `cache-from`        | CSV     | List of [external cache sources](https://github.com/docker/buildx#--cache-fromnametypetypekeyvalue) (eg. `type=local,src=path/to/dir`) |
-| `cache-to`          | CSV     | List of [cache export destinations](https://github.com/docker/buildx#--cache-tonametypetypekeyvalue) (eg. `type=local,dest=path/to/dir`) |
-| `secrets`           | CSV     | List of secrets to expose to the build (eg. `key=value`, `GIT_AUTH_TOKEN=mytoken`) |
+| Name                | Type     | Description                        |
+|---------------------|----------|------------------------------------|
+| `builder`           | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action) |
+| `context`           | String   | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context)) |
+| `file`              | String   | Path to the Dockerfile (default `Dockerfile`) |
+| `build-args`        | List     | List of build-time variables |
+| `labels`            | List     | List of metadata for an image |
+| `tags`              | List/CSV | List of tags |
+| `pull`              | Bool     | Always attempt to pull a newer version of the image (default `false`) |
+| `target`            | String   | Sets the target stage to build |
+| `allow`             | List/CSV | List of [extra privileged entitlement](https://github.com/docker/buildx#--allowentitlement) (eg. `network.host,security.insecure`) |
+| `no-cache`          | Bool     | Do not use cache when building the image (default `false`) |
+| `platforms`         | List/CSV | List of [target platforms](https://github.com/docker/buildx#---platformvaluevalue) for build |
+| `load`              | Bool     | [Load](https://github.com/docker/buildx#--load) is a shorthand for `--output=type=docker` (default `false`) |
+| `push`              | Bool     | [Push](https://github.com/docker/buildx#--push) is a shorthand for `--output=type=registry` (default `false`) |
+| `outputs`           | List     | List of [output destinations](https://github.com/docker/buildx#-o---outputpath-typetypekeyvalue) (format: `type=local,dest=path`) |
+| `cache-from`        | List     | List of [external cache sources](https://github.com/docker/buildx#--cache-fromnametypetypekeyvalue) (eg. `type=local,src=path/to/dir`) |
+| `cache-to`          | List     | List of [cache export destinations](https://github.com/docker/buildx#--cache-tonametypetypekeyvalue) (eg. `type=local,dest=path/to/dir`) |
+| `secrets`           | List     | List of secrets to expose to the build (eg. `key=value`, `GIT_AUTH_TOKEN=mytoken`) |
 
-> `List` type can be a comma or newline-delimited string
-> ```yaml
-> tags: name/app:latest,name/app:1.0.0
-> ```
-> ```yaml
-> tags: |
->   name/app:latest
->   name/app:1.0.0
-> ```
-
-> `CSV` type must be a newline-delimited string
-> ```yaml
-> cache-from: user/app:cache
-> ```
+> `List` type is a newline-delimited string
 > ```yaml
 > cache-from: |
 >   user/app:cache
 >   type=local,src=path/to/dir
+> ```
+
+> `CSV` type is a comma-delimited string
+> ```yaml
+> tags: name/app:latest,name/app:1.0.0
 > ```
 
 ### outputs

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -34,11 +34,13 @@ describe('getArgs', () => {
     [
       '0.4.2',
       new Map<string, string>([
-        // noop
+        ['build-args', 'MY_ARG=val1,val2,val3\nARG=val'],
       ]),
       [
         'buildx',
         'build',
+        '--build-arg', 'MY_ARG=val1,val2,val3',
+        '--build-arg', 'ARG=val',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--file', 'Dockerfile',
         'https://github.com/docker/build-push-action.git#test-jest'
@@ -48,11 +50,14 @@ describe('getArgs', () => {
       '0.4.2',
       new Map<string, string>([
         ['context', '.'],
+        ['labels', 'org.opencontainers.image.title=buildkit\norg.opencontainers.image.description=concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit'],
         ['outputs', 'type=local,dest=./release-out']
       ]),
       [
         'buildx',
         'build',
+        '--label', 'org.opencontainers.image.title=buildkit',
+        '--label', 'org.opencontainers.image.description=concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit',
         '--output', 'type=local,dest=./release-out',
         '--file', 'Dockerfile',
         '.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -14867,8 +14867,8 @@ function getInputs(defaultContext) {
         return {
             context: core.getInput('context') || defaultContext,
             file: core.getInput('file') || 'Dockerfile',
-            buildArgs: yield getInputList('build-args'),
-            labels: yield getInputList('labels'),
+            buildArgs: yield getInputList('build-args', true),
+            labels: yield getInputList('labels', true),
             tags: yield getInputList('tags'),
             pull: /true/i.test(core.getInput('pull')),
             target: core.getInput('target'),

--- a/src/context.ts
+++ b/src/context.ts
@@ -46,8 +46,8 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
   return {
     context: core.getInput('context') || defaultContext,
     file: core.getInput('file') || 'Dockerfile',
-    buildArgs: await getInputList('build-args'),
-    labels: await getInputList('labels'),
+    buildArgs: await getInputList('build-args', true),
+    labels: await getInputList('labels', true),
     tags: await getInputList('tags'),
     pull: /true/i.test(core.getInput('pull')),
     target: core.getInput('target'),


### PR DESCRIPTION
```yaml
          labels: |
            org.opencontainers.image.title=buildkit
            org.opencontainers.image.description=concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit
          build-args: |
            MY_ARG=val1,val2
```

Will produce:

```
--build-arg MY_ARG=val1
--build-arg val2
--label org.opencontainers.image.title=buildkit
--label org.opencontainers.image.description=concurrent
--label cache-efficient
--label and Dockerfile-agnostic builder toolkit
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>