### PR TITLE
docs(README): Improve example of `file` option so it's obvious that it is not relative to `context` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ Following inputs can be used as `step.with` keys
 |---------------------|----------|------------------------------------|
 | `builder`           | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action) |
 | `context`           | String   | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context)) |
-| `file`              | String   | Path to the Dockerfile (default `Dockerfile`) |
+| `file`              | String   | Path to the Dockerfile (default `./Dockerfile`) |
 | `build-args`        | List     | List of build-time variables |
 | `labels`            | List     | List of metadata for an image |
 | `tags`              | List/CSV | List of tags |


### PR DESCRIPTION
I just spent 30 min debugging "why is buildx not working on my github runner?", just to learn that the `file` option is not relative to the `context` option. (So basically if you want to build'n'push from a different directory, which has the `Dockerfile` and should be the `context`, you need to update both options.)

Especially since the error message that appears then isn't really helpful:

![image](https://user-images.githubusercontent.com/1862580/96621313-c6265880-1308-11eb-8a97-0ade003562db.png)

Changing from

```
          context: ./images/php/${{ env.PHP_VERSION }}/
```

to

```
          context: ./images/php/${{ env.PHP_VERSION }}/
          file: ./images/php/${{ env.PHP_VERSION }}/Dockerfile
```

fixed the problem in my case.

(The error message could be improved as well I guess, but let's say that's another nice-to-have thing.)