### PR TITLE
Added dockerfile path to image label

### DIFF
--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -10,6 +10,7 @@ jest.spyOn(context, 'tmpDir').mockImplementation((): string => {
   const tmpDir = path.join('/tmp/.docker-build-push-jest').split(path.sep).join(path.posix.sep);
   if (!fs.existsSync(tmpDir)) {
     fs.mkdirSync(tmpDir, {recursive: true});
+    2;
   }
   return tmpDir;
 });
@@ -146,6 +147,8 @@ describe('getArgs', () => {
       [
         'buildx',
         'build',
+        '--label', 'org.opencontainers.image.source=https://github.com/docker/build-push-action.git',
+        '--label', 'dockerfile-path=./test/Dockerfile',
         '--platform', 'linux/amd64,linux/arm64',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--secret', 'id=GIT_AUTH_TOKEN,src=/tmp/.docker-build-push-jest/.tmpname-jest',
@@ -153,6 +156,59 @@ describe('getArgs', () => {
         '--builder', 'builder-git-context-2',
         '--push',
         'https://github.com/docker/build-push-action.git#heads/master'
+      ]
+    ],
+    [
+      '0.4.2',
+      new Map<string, string>([
+        ['context', '.'],
+        ['labels', 'org.opencontainers.image.source=UserProvidedSourceLabel'],
+        ['outputs', 'type=image,dest=./release-out']
+      ]),
+      [
+        'buildx',
+        'build',
+        '--label', 'org.opencontainers.image.source=UserProvidedSourceLabel',
+        '--label', 'dockerfile-path=Dockerfile',
+        '--output', 'type=image,dest=./release-out',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--file', 'Dockerfile',
+        '.'
+      ]
+    ],
+    [
+      '0.4.2',
+      new Map<string, string>([
+        ['context', '.'],
+        ['outputs', 'type=registry,dest=./release-out']
+      ]),
+      [
+        'buildx',
+        'build',
+        '--label', 'org.opencontainers.image.source=https://github.com/docker/build-push-action.git',
+        '--label', 'dockerfile-path=Dockerfile',
+        '--output', 'type=registry,dest=./release-out',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--file', 'Dockerfile',
+        '.'
+      ]
+    ],
+    [
+      '0.4.2',
+      new Map<string, string>([
+        ['context', '.'],
+        ['labels', 'org.opencontainers.image.source=UserProvidedSourceLabel'],
+        ['load', 'true']
+      ]),
+      [
+        'buildx',
+        'build',
+        '--label', 'org.opencontainers.image.source=UserProvidedSourceLabel',
+        '--label', 'dockerfile-path=Dockerfile',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--file', 'Dockerfile',
+        '--load',
+        '.'
       ]
     ]
   ])(

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -147,8 +147,31 @@ describe('getArgs', () => {
       [
         'buildx',
         'build',
-        '--label', 'org.opencontainers.image.source=https://github.com/docker/build-push-action.git',
-        '--label', 'dockerfile-path=./test/Dockerfile',
+        '--platform', 'linux/amd64,linux/arm64',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--secret', 'id=GIT_AUTH_TOKEN,src=/tmp/.docker-build-push-jest/.tmpname-jest',
+        '--file', './test/Dockerfile',
+        '--builder', 'builder-git-context-2',
+        '--push',
+        'https://github.com/docker/build-push-action.git#heads/master'
+      ]
+    ],
+    [
+      '0.4.2',
+      new Map<string, string>([
+        ['context', 'https://github.com/docker/build-push-action.git#heads/master'],
+        ['tag', 'localhost:5000/name/app:latest'],
+        ['platforms', 'linux/amd64,linux/arm64'],
+        ['secrets', 'GIT_AUTH_TOKEN=abcdefghijklmno=0123456789'],
+        ['file', './test/Dockerfile'],
+        ['builder', 'builder-git-context-2'],
+        ['push', 'true'],
+        ['trace-data', 'true']
+      ]),
+      [
+        'buildx',
+        'build',
+        '--label', 'dockerfile-path=https://github.com/docker/build-push-action.git#test-jest/./test/Dockerfile',
         '--platform', 'linux/amd64,linux/arm64',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--secret', 'id=GIT_AUTH_TOKEN,src=/tmp/.docker-build-push-jest/.tmpname-jest',
@@ -162,14 +185,13 @@ describe('getArgs', () => {
       '0.4.2',
       new Map<string, string>([
         ['context', '.'],
-        ['labels', 'org.opencontainers.image.source=UserProvidedSourceLabel'],
-        ['outputs', 'type=image,dest=./release-out']
+        ['outputs', 'type=image,dest=./release-out'],
+        ['trace-data', 'true']
       ]),
       [
         'buildx',
         'build',
-        '--label', 'org.opencontainers.image.source=UserProvidedSourceLabel',
-        '--label', 'dockerfile-path=Dockerfile',
+        '--label', 'dockerfile-path=https://github.com/docker/build-push-action.git#test-jest/Dockerfile',
         '--output', 'type=image,dest=./release-out',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--file', 'Dockerfile',
@@ -180,13 +202,13 @@ describe('getArgs', () => {
       '0.4.2',
       new Map<string, string>([
         ['context', '.'],
-        ['outputs', 'type=registry,dest=./release-out']
+        ['outputs', 'type=registry,dest=./release-out'],
+        ['trace-data', 'true']
       ]),
       [
         'buildx',
         'build',
-        '--label', 'org.opencontainers.image.source=https://github.com/docker/build-push-action.git',
-        '--label', 'dockerfile-path=Dockerfile',
+        '--label', 'dockerfile-path=https://github.com/docker/build-push-action.git#test-jest/Dockerfile',
         '--output', 'type=registry,dest=./release-out',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--file', 'Dockerfile',
@@ -197,14 +219,13 @@ describe('getArgs', () => {
       '0.4.2',
       new Map<string, string>([
         ['context', '.'],
-        ['labels', 'org.opencontainers.image.source=UserProvidedSourceLabel'],
-        ['load', 'true']
+        ['load', 'true'],
+        ['trace-data', 'true']
       ]),
       [
         'buildx',
         'build',
-        '--label', 'org.opencontainers.image.source=UserProvidedSourceLabel',
-        '--label', 'dockerfile-path=Dockerfile',
+        '--label', 'dockerfile-path=https://github.com/docker/build-push-action.git#test-jest/Dockerfile',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--file', 'Dockerfile',
         '--load',

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,10 @@ inputs:
   ssh:
     description: "List of SSH agent socket or keys to expose to the build"
     required: false
-
+  trace-data:
+    description: "Flag to indicate whether link to dockerfile is added to image labels or not"
+    default: 'false'
+    required: false
 outputs:
   digest:
     description: 'Image content-addressable identifier also called a digest'

--- a/dist/index.js
+++ b/dist/index.js
@@ -12092,7 +12092,8 @@ function getInputs(defaultContext) {
                 userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1))) {
             //Add link to dockerfile as label
             let dockerfilePath = userInputs.file;
-            userInputs.labels.push(`dockerfile-path=${defaultContext}/${dockerfilePath}`);
+            let repoPath = defaultContext.replace('#head', '/blob');
+            userInputs.labels.push(`dockerfile-path=${repoPath}/${dockerfilePath}`);
         }
         return userInputs;
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2373,6 +2373,7 @@ const context = __importStar(__webpack_require__(842));
 const exec = __importStar(__webpack_require__(757));
 const stateHelper = __importStar(__webpack_require__(647));
 const core = __importStar(__webpack_require__(186));
+const github = __importStar(__webpack_require__(438));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -2387,6 +2388,9 @@ function run() {
             core.info(`📣 Buildx version: ${buildxVersion}`);
             const defContext = context.defaultContext();
             let inputs = yield context.getInputs(defContext);
+            //Add dockerfile path to label
+            let dockerfilePath = core.getInput('file') || 'Dockerfile';
+            inputs.labels.push(`org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/${dockerfilePath}`);
             core.info(`🏃 Starting build...`);
             const args = yield context.getArgs(inputs, defContext, buildxVersion);
             yield exec.exec('docker', args).then(res => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12092,7 +12092,14 @@ function getInputs(defaultContext) {
                 userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1))) {
             //Add link to dockerfile as label
             let dockerfilePath = userInputs.file;
-            let repoPath = defaultContext.replace('#head', '/blob');
+            let stringToReplace = '';
+            if (defaultContext.indexOf('#heads')) {
+                stringToReplace = '.git#heads';
+            }
+            else if (defaultContext.indexOf('#tags')) {
+                stringToReplace = '.git#tags';
+            }
+            let repoPath = defaultContext.replace(stringToReplace, '/blob');
             userInputs.labels.push(`dockerfile-path=${repoPath}/${dockerfilePath}`);
         }
         return userInputs;

--- a/dist/index.js
+++ b/dist/index.js
@@ -2391,7 +2391,7 @@ function run() {
             //Add dockerfile path to label
             let dockerfilePath = core.getInput('file') || 'Dockerfile';
             inputs.labels.push(`org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`);
-            inputs.labels.push(`dockerfilePath=${dockerfilePath}`);
+            inputs.labels.push(`dockerfile-path=${dockerfilePath}`);
             core.info(`🏃 Starting build...`);
             const args = yield context.getArgs(inputs, defContext, buildxVersion);
             yield exec.exec('docker', args).then(res => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12085,14 +12085,19 @@ function getInputs(defaultContext) {
             githubToken: core.getInput('github-token'),
             ssh: yield getInputList('ssh')
         };
-        //Add repo as source-label if not already supplied by user
-        const sourceLabelKey = 'org.opencontainers.image.source';
-        if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
-            userInputs.labels.push(`${sourceLabelKey}=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`);
+        if (userInputs.load == true ||
+            userInputs.push == true ||
+            userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1)) {
+            //Add repo as source-label if not already supplied by user
+            const sourceLabelKey = 'org.opencontainers.image.source';
+            if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
+                const githubOwnerRepoUrl = defaultContext.split('#')[0];
+                userInputs.labels.push(`${sourceLabelKey}=${githubOwnerRepoUrl}`);
+            }
+            //Add dockerfile path as label
+            let dockerfilePath = userInputs.file;
+            userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
         }
-        //Add dockerfile path as label
-        let dockerfilePath = userInputs.file;
-        userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
         return userInputs;
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -12083,20 +12083,16 @@ function getInputs(defaultContext) {
             cacheTo: yield getInputList('cache-to', true),
             secrets: yield getInputList('secrets', true),
             githubToken: core.getInput('github-token'),
-            ssh: yield getInputList('ssh')
+            ssh: yield getInputList('ssh'),
+            traceData: core.getInput('trace-data') || 'false'
         };
-        if (userInputs.load == true ||
-            userInputs.push == true ||
-            userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1)) {
-            //Add repo as source-label if not already supplied by user
-            const sourceLabelKey = 'org.opencontainers.image.source';
-            if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
-                const githubOwnerRepoUrl = defaultContext.split('#')[0];
-                userInputs.labels.push(`${sourceLabelKey}=${githubOwnerRepoUrl}`);
-            }
-            //Add dockerfile path as label
+        if (userInputs.traceData == 'true' && //if user explictly asks to add traceData
+            (userInputs.load == true ||
+                userInputs.push == true ||
+                userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1))) {
+            //Add link to dockerfile as label
             let dockerfilePath = userInputs.file;
-            userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
+            userInputs.labels.push(`dockerfile-path=${defaultContext}/${dockerfilePath}`);
         }
         return userInputs;
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2390,7 +2390,8 @@ function run() {
             let inputs = yield context.getInputs(defContext);
             //Add dockerfile path to label
             let dockerfilePath = core.getInput('file') || 'Dockerfile';
-            inputs.labels.push(`org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/${dockerfilePath}`);
+            inputs.labels.push(`org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`);
+            inputs.labels.push(`dockerfilePath=${dockerfilePath}`);
             core.info(`🏃 Starting build...`);
             const args = yield context.getArgs(inputs, defContext, buildxVersion);
             yield exec.exec('docker', args).then(res => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -85,7 +85,8 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
   ) {
     //Add link to dockerfile as label
     let dockerfilePath = userInputs.file;
-    userInputs.labels.push(`dockerfile-path=${defaultContext}/${dockerfilePath}`);
+    let repoPath = defaultContext.replace('#head', '/blob');
+    userInputs.labels.push(`dockerfile-path=${repoPath}/${dockerfilePath}`);
   }
 
   return userInputs;

--- a/src/context.ts
+++ b/src/context.ts
@@ -76,17 +76,22 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
     ssh: await getInputList('ssh')
   };
 
-  //Add repo as source-label if not already supplied by user
-  const sourceLabelKey = 'org.opencontainers.image.source';
-  if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
-    userInputs.labels.push(
-      `${sourceLabelKey}=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`
-    );
-  }
+  if (
+    userInputs.load == true ||
+    userInputs.push == true ||
+    userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1)
+  ) {
+    //Add repo as source-label if not already supplied by user
+    const sourceLabelKey = 'org.opencontainers.image.source';
+    if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
+      const githubOwnerRepoUrl = defaultContext.split('#')[0];
+      userInputs.labels.push(`${sourceLabelKey}=${githubOwnerRepoUrl}`);
+    }
 
-  //Add dockerfile path as label
-  let dockerfilePath = userInputs.file;
-  userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
+    //Add dockerfile path as label
+    let dockerfilePath = userInputs.file;
+    userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
+  }
 
   return userInputs;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -85,7 +85,14 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
   ) {
     //Add link to dockerfile as label
     let dockerfilePath = userInputs.file;
-    let repoPath = defaultContext.replace('#head', '/blob');
+    let stringToReplace = '';
+    if (defaultContext.indexOf('#heads')) {
+      stringToReplace = '.git#heads';
+    } else if (defaultContext.indexOf('#tags')) {
+      stringToReplace = '.git#tags';
+    }
+
+    let repoPath = defaultContext.replace(stringToReplace, '/blob');
     userInputs.labels.push(`dockerfile-path=${repoPath}/${dockerfilePath}`);
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -54,7 +54,6 @@ export function tmpNameSync(options?: tmp.TmpNameOptions): string {
 }
 
 export async function getInputs(defaultContext: string): Promise<Inputs> {
-  
   let userInputs = {
     context: core.getInput('context') || defaultContext,
     file: core.getInput('file') || 'Dockerfile',
@@ -79,7 +78,7 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
 
   //Add repo as source-label if not already supplied by user
   const sourceLabelKey = 'org.opencontainers.image.source';
-  if( userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true ) == null){
+  if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
     userInputs.labels.push(
       `${sourceLabelKey}=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`
     );

--- a/src/context.ts
+++ b/src/context.ts
@@ -73,24 +73,19 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
     cacheTo: await getInputList('cache-to', true),
     secrets: await getInputList('secrets', true),
     githubToken: core.getInput('github-token'),
-    ssh: await getInputList('ssh')
+    ssh: await getInputList('ssh'),
+    traceData: core.getInput('trace-data') || 'false'
   };
 
   if (
-    userInputs.load == true ||
-    userInputs.push == true ||
-    userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1)
+    userInputs.traceData == 'true' && //if user explictly asks to add traceData
+    (userInputs.load == true ||
+      userInputs.push == true ||
+      userInputs.outputs.find(val => val.indexOf('type=image') > -1 || val.indexOf('type=registry') > -1))
   ) {
-    //Add repo as source-label if not already supplied by user
-    const sourceLabelKey = 'org.opencontainers.image.source';
-    if (userInputs.labels.find(val => val.startsWith(sourceLabelKey) == true) == null) {
-      const githubOwnerRepoUrl = defaultContext.split('#')[0];
-      userInputs.labels.push(`${sourceLabelKey}=${githubOwnerRepoUrl}`);
-    }
-
-    //Add dockerfile path as label
+    //Add link to dockerfile as label
     let dockerfilePath = userInputs.file;
-    userInputs.labels.push(`dockerfile-path=${dockerfilePath}`);
+    userInputs.labels.push(`dockerfile-path=${defaultContext}/${dockerfilePath}`);
   }
 
   return userInputs;

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ async function run(): Promise<void> {
     inputs.labels.push(
       `org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`
     );
-    inputs.labels.push(`dockerfilePath=${dockerfilePath}`);
+    inputs.labels.push(`dockerfile-path=${dockerfilePath}`);
 
     core.info(`🏃 Starting build...`);
     const args: string[] = await context.getArgs(inputs, defContext, buildxVersion);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import * as context from './context';
 import * as exec from './exec';
 import * as stateHelper from './state-helper';
 import * as core from '@actions/core';
-import * as github from '@actions/github';
 
 async function run(): Promise<void> {
   try {
@@ -23,13 +22,6 @@ async function run(): Promise<void> {
 
     const defContext = context.defaultContext();
     let inputs: context.Inputs = await context.getInputs(defContext);
-
-    //Add dockerfile path to label
-    let dockerfilePath = core.getInput('file') || 'Dockerfile';
-    inputs.labels.push(
-      `org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`
-    );
-    inputs.labels.push(`dockerfile-path=${dockerfilePath}`);
 
     core.info(`🏃 Starting build...`);
     const args: string[] = await context.getArgs(inputs, defContext, buildxVersion);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as context from './context';
 import * as exec from './exec';
 import * as stateHelper from './state-helper';
 import * as core from '@actions/core';
+import * as github from '@actions/github';
 
 async function run(): Promise<void> {
   try {
@@ -22,6 +23,12 @@ async function run(): Promise<void> {
 
     const defContext = context.defaultContext();
     let inputs: context.Inputs = await context.getInputs(defContext);
+
+    //Add dockerfile path to label
+    let dockerfilePath = core.getInput('file') || 'Dockerfile';
+    inputs.labels.push(
+      `org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/${dockerfilePath}`
+    );
 
     core.info(`🏃 Starting build...`);
     const args: string[] = await context.getArgs(inputs, defContext, buildxVersion);

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,9 @@ async function run(): Promise<void> {
     //Add dockerfile path to label
     let dockerfilePath = core.getInput('file') || 'Dockerfile';
     inputs.labels.push(
-      `org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}/${dockerfilePath}`
+      `org.opencontainers.image.source=https://github.com/${github.context.repo.owner}/${github.context.repo.repo}`
     );
+    inputs.labels.push(`dockerfilePath=${dockerfilePath}`);
 
     core.info(`🏃 Starting build...`);
     const args: string[] = await context.getArgs(inputs, defContext, buildxVersion);


### PR DESCRIPTION
This change is part of an effort to improve traceability of resources which are built and deployed using GitHub workflows. We want to save the dockerfile path - which is used in building the image - through this action.
`Points to note:`
- Instead of the user specifying the path explicitly for this, we will use the path that the action uses to build the image - so no change for the user.
- This image label can later be used for traceability by any action that is used to deploy the image.