### PR TITLE
Set container label "org.opencontainers.image.source" to establish a repository connection on github

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -140,7 +140,7 @@ steps:
       push: ${{ github.event_name != 'pull_request' }}
       tags: ${{ steps.prep.outputs.tags }}
       labels: |
-        org.opencontainers.image.source=https://github.com/${{ github.repository }}
+        org.opencontainers.image.source=${{ github.event.repository.html_url }}
         org.opencontainers.image.created=${{ steps.prep.outputs.created }}
         org.opencontainers.image.revision=${{ github.sha }}
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -140,7 +140,7 @@ steps:
       push: ${{ github.event_name != 'pull_request' }}
       tags: ${{ steps.prep.outputs.tags }}
       labels: |
-        org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+        org.opencontainers.image.source=https://github.com/${{ github.repository }}
         org.opencontainers.image.created=${{ steps.prep.outputs.created }}
         org.opencontainers.image.revision=${{ github.sha }}
 ```


### PR DESCRIPTION
In the Upgrade Path, the container label `org.opencontainers.image.source` gets set:

``` 
org.opencontainers.image.source = "https://github.com/<OWNER>/<NAME>.git"
```

When using the Github Container Registry, there is an option to [Connecting a repository to a container image](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image).

GitHub itself can also create a connection automatically, depending on the value of the label `org.opencontainers.image.source`.
With the `.git`-prefix this connection can't be established:

<img width="1020" alt="Screen Shot 2020-11-08 at 19 47 03" src="https://user-images.githubusercontent.com/320064/98481950-59fb8e00-21fe-11eb-9543-6dc96c41b73f.png">

<img width="1019" alt="Screen Shot 2020-11-08 at 19 47 11" src="https://user-images.githubusercontent.com/320064/98481952-5cf67e80-21fe-11eb-8d42-b908ab1c0cd1.png">

This PR switches the label to a value without the `.git` prefix:

``` 
org.opencontainers.image.source = "https://github.com/<OWNER>/<NAME>"
```

With this, the connection can be established:

<img width="1030" alt="Screen Shot 2020-11-08 at 20 10 53" src="https://user-images.githubusercontent.com/320064/98481994-9202d100-21fe-11eb-90f3-f39916675f75.png">
