### PR TITLE
Use default behavior for file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ Following inputs can be used as `step.with` keys
 |---------------------|----------|------------------------------------|
 | `builder`           | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action) |
 | `context`           | String   | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context)) |
-| `file`              | String   | Path to the Dockerfile (default `./Dockerfile`) |
+| `file`              | String   | Path to the Dockerfile. (default `{context}/Dockerfile`) |
 | `build-args`        | List     | List of build-time variables |
 | `labels`            | List     | List of metadata for an image |
 | `tags`              | List/CSV | List of tags |

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -147,7 +147,6 @@ describe('getArgs', () => {
         'buildx',
         'build',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
-        '--file', 'Dockerfile',
         '.'
       ]
     ],
@@ -162,7 +161,6 @@ describe('getArgs', () => {
         '--build-arg', 'MY_ARG=val1,val2,val3',
         '--build-arg', 'ARG=val',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
-        '--file', 'Dockerfile',
         'https://github.com/docker/build-push-action.git#test-jest'
       ]
     ],
@@ -177,7 +175,6 @@ describe('getArgs', () => {
         '--tag', 'name/app:7.4',
         '--tag', 'name/app:latest',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
-        '--file', 'Dockerfile',
         'https://github.com/docker/build-push-action.git#test-jest'
       ]
     ],
@@ -194,7 +191,6 @@ describe('getArgs', () => {
         '--label', 'org.opencontainers.image.title=buildkit',
         '--label', 'org.opencontainers.image.description=concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit',
         '--output', 'type=local,dest=./release-out',
-        '--file', 'Dockerfile',
         '.'
       ]
     ],
@@ -208,7 +204,6 @@ describe('getArgs', () => {
         'buildx',
         'build',
         '--platform', 'linux/amd64,linux/arm64',
-        '--file', 'Dockerfile',
         '.'
       ]
     ],
@@ -221,7 +216,6 @@ describe('getArgs', () => {
         'buildx',
         'build',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
-        '--file', 'Dockerfile',
         '.'
       ]
     ],
@@ -236,7 +230,6 @@ describe('getArgs', () => {
         'build',
         '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
         '--secret', 'id=GIT_AUTH_TOKEN,src=/tmp/.docker-build-push-jest/.tmpname-jest',
-        '--file', 'Dockerfile',
         '.'
       ]
     ],
@@ -251,7 +244,6 @@ describe('getArgs', () => {
         'build',
         '--output', '.',
         '--secret', 'id=GIT_AUTH_TOKEN,src=/tmp/.docker-build-push-jest/.tmpname-jest',
-        '--file', 'Dockerfile',
         'https://github.com/docker/build-push-action.git#test-jest'
       ]
     ],

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
   file:
     description: "Path to the Dockerfile"
     required: false
-    default: './Dockerfile'
   build-args:
     description: "List of build-time variables"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -12987,7 +12987,7 @@ function getInputs(defaultContext) {
     return __awaiter(this, void 0, void 0, function* () {
         return {
             context: core.getInput('context') || defaultContext,
-            file: core.getInput('file') || 'Dockerfile',
+            file: core.getInput('file'),
             buildArgs: yield getInputList('build-args', true),
             labels: yield getInputList('labels', true),
             tags: yield getInputList('tags'),

--- a/src/context.ts
+++ b/src/context.ts
@@ -57,7 +57,7 @@ export function tmpNameSync(options?: tmp.TmpNameOptions): string {
 export async function getInputs(defaultContext: string): Promise<Inputs> {
   return {
     context: core.getInput('context') || defaultContext,
-    file: core.getInput('file') || 'Dockerfile',
+    file: core.getInput('file'),
     buildArgs: await getInputList('build-args', true),
     labels: await getInputList('labels', true),
     tags: await getInputList('tags'),


### PR DESCRIPTION
Our team hit this issue today, but with `buildx` the file argument needs to be specified from the root directory not just the relative directory from the `context` (`PATH`) argument .

See:
<img width="915" alt="image" src="https://user-images.githubusercontent.com/13482895/100939863-06aaf180-34c5-11eb-972b-27a83984d6ed.png">

This updates the readme to reflect this fact.