### PR TITLE
Set mode=max to cache intermediate stages (docs update only)

### DIFF
--- a/docs/advanced/cache.md
+++ b/docs/advanced/cache.md
@@ -41,7 +41,7 @@ jobs:
           push: true
           tags: user/app:latest
           cache-from: type=registry,ref=user/app:latest
-          cache-to: type=inline
+          cache-to: type=inline,mode=max
 ```
 
 ## GitHub cache
@@ -95,7 +95,7 @@ jobs:
           push: true
           tags: user/app:latest
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       -
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252


### PR DESCRIPTION
Add `mode=max` option in the cache.md documentation.

Background: buildx caches layers only in the final stage by default.

To speedup multi-stage Dockerfile build, better to set `mode=max` in CI: https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to
