### PR TITLE
Composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,3 +673,29 @@ jobs:
         name: Dump context
         if: always()
         uses: crazy-max/ghaction-dump-context@v1
+
+  composite:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Build with composite
+        uses: ./composite
+        with:
+          context: .
+          file: ./test/Dockerfile
+          images: |
+            localhost:5000/name/app
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+      -
+        name: Dump context
+        if: always()
+        uses: crazy-max/ghaction-dump-context@v1

--- a/composite/action.yml
+++ b/composite/action.yml
@@ -1,0 +1,69 @@
+name: 'Docker composite action'
+description: 'Set up Buildx and QEMU + Cache + Metadata + Build and push'
+
+inputs:
+  images:
+    description: "List of Docker image slugs (eg. name/app)"
+    required: true
+  context:
+    description: "Build's context is the set of files located in the specified PATH or URL. (default Git context)"
+    required: false
+  file:
+    description: "Path to the Dockerfile. (default {context}/Dockerfile)"
+    required: false
+  platforms:
+    description: "List of target platforms (eg. linux/amd64)"
+    required: false
+  cachekey:
+    description: "Cache key for local cache. (default buildx-{github.repository.name})"
+    required: false
+    default: "buildx-${{ github.repository.name}}"
+  push:
+    description: "Push image to the registry"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    -
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-${{ inputs.cachekey }}-cache
+        key: ${{ runner.os }}-${{ inputs.cachekey }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cachekey }}-
+    -
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ inputs.images }}
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+    -
+      uses: docker/setup-qemu-action@v1
+    -
+      uses: docker/setup-buildx-action@v1
+    -
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        push: ${{ inputs.push }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ inputs.platforms }}
+        cache-from: type=local,src=/tmp/.${{ inputs.cachekey }}-cache
+        cache-to: type=local,dest=/tmp/.${{ inputs.cachekey }}-cache-new,mode=max
+    -
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      run: |
+        rm -rf /tmp/.${{ inputs.cachekey }}-cache
+        mv /tmp/.${{ inputs.cachekey }}-cache-new /tmp/.${{ inputs.cachekey }}-cache
+      shell: bash


### PR DESCRIPTION
Fixes #208

Try-out the composite feature which now supports `uses:` keyword:
* Set up Buildx and QEMU
* Cache
* Metadata
* Build and push

Usage:

```yaml
name: ci

on:
  push:
    branches:
      - 'master'

jobs:
  docker:
    runs-on: ubuntu-latest
    steps:
      -
        name: Checkout
        uses: actions/checkout@v2
      -
        name: Login to DockerHub
        uses: docker/login-action@v1
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_TOKEN }}
      -
        name: Build with composite
        uses: docker/build-push-action/composite@v2
        with:
          context: .
          images: |
            user/app
          platforms: linux/amd64,linux/arm64
          push: ${{ github.event_name != 'pull_request' }}
```

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>