### PR TITLE
readme: remove v1 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,6 @@
 [![Test workflow](https://img.shields.io/github/workflow/status/docker/build-push-action/test?label=test&logo=github&style=flat-square)](https://github.com/docker/build-push-action/actions?workflow=test)
 [![Codecov](https://img.shields.io/codecov/c/github/docker/build-push-action?logo=codecov&style=flat-square)](https://codecov.io/gh/docker/build-push-action)
 
-## Upgrade from v1
-
-`v2` of this action includes significant updates and now uses Docker [Buildx](https://github.com/docker/buildx). It's
-also rewritten as a [typescript-action](https://github.com/actions/typescript-action/) to be as close as possible
-of the [GitHub Runner](https://github.com/actions/virtual-environments) during its execution.
-
-[Upgrade notes](UPGRADE.md) with many [usage examples](#advanced-usage) have been added to handle most use cases but
-`v1` is still available through [`releases/v1` branch](https://github.com/docker/build-push-action/tree/releases/v1).
-
 ## About
 
 GitHub Action to build and push Docker images with [Buildx](https://github.com/docker/buildx) with full support of the

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -28,7 +28,7 @@
 # v1
 steps:
   -
-    name: Checkout code
+    name: Checkout
     uses: actions/checkout@v2
   -
     name: Build and push Docker images
@@ -47,7 +47,7 @@ steps:
 # v2
 steps:
   -
-    name: Checkout code
+    name: Checkout
     uses: actions/checkout@v2
   -
     name: Set up Docker Buildx
@@ -79,7 +79,7 @@ steps:
 # v1
 steps:
   -
-    name: Checkout code
+    name: Checkout
     uses: actions/checkout@v2
   -
     name: Build and push Docker images


### PR DESCRIPTION
More than a year has passed since v2 so time to remove v1 section from README. Not sure about removing `UPGRADE.md` though. cc @tonistiigi @thaJeztah @chris-crone 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>