### PR TITLE
Change the default branch in code examples from "master" to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   docker:
@@ -116,7 +116,7 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   docker:


### PR DESCRIPTION
GitHub has changed the default branch name from "master" to "main". For people who copy and paste these code snippets into their projects, it becomes problematic and confusing.