### PR TITLE
Add context-subdir input

### DIFF
--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -491,6 +491,43 @@ nproc=3`],
         '.'
       ]
     ],
+    [
+      15,
+      '0.7.0',
+      new Map<string, string>([
+        ['context-subdir', 'test'],
+        ['load', 'false'],
+        ['no-cache', 'false'],
+        ['pull', 'false'],
+        ['push', 'false'],
+      ]),
+      [
+        'buildx',
+        'build',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--metadata-file', '/tmp/.docker-build-push-jest/metadata-file',
+        'https://github.com/docker/build-push-action.git#refs/heads/test-jest:test'
+      ]
+    ],
+    [
+      16,
+      '0.7.0',
+      new Map<string, string>([
+        ['context', './test'],
+        ['context-subdir', 'should-be-ignored'],
+        ['load', 'false'],
+        ['no-cache', 'false'],
+        ['pull', 'false'],
+        ['push', 'false'],
+      ]),
+      [
+        'buildx',
+        'build',
+        '--iidfile', '/tmp/.docker-build-push-jest/iidfile',
+        '--metadata-file', '/tmp/.docker-build-push-jest/metadata-file',
+        './test'
+      ]
+    ],
   ])(
     '[%d] given %p with %p as inputs, returns %p',
     async (num: number, buildxVersion: string, inputs: Map<string, any>, expected: Array<string>) => {

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   context:
     description: "Build's context is the set of files located in the specified PATH or URL"
     required: false
+  context-subdir:
+    description: "Subdirectory of the git repo to use as the docker build context (when using a URL-based context)"
+    required: false
   file:
     description: "Path to the Dockerfile"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -276,6 +276,7 @@ function getInputs(defaultContext) {
             cacheTo: yield getInputList('cache-to', true),
             cgroupParent: core.getInput('cgroup-parent'),
             context: core.getInput('context') || defaultContext,
+            contextSubdir: core.getInput('context-subdir'),
             file: core.getInput('file'),
             labels: yield getInputList('labels', true),
             load: core.getBooleanInput('load'),
@@ -302,7 +303,16 @@ function getArgs(inputs, defaultContext, buildxVersion) {
         let args = ['buildx'];
         args.push.apply(args, yield getBuildArgs(inputs, defaultContext, buildxVersion));
         args.push.apply(args, yield getCommonArgs(inputs, buildxVersion));
-        args.push(inputs.context);
+        let context = inputs.context;
+        if (inputs.contextSubdir) {
+            if (context == defaultContext) {
+                context = `${context}:${inputs.contextSubdir}`;
+            }
+            else {
+                core.warning('"context-subdir" input is ignored when a "context" input is present');
+            }
+        }
+        args.push(context);
         return args;
     });
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -20,6 +20,7 @@ export interface Inputs {
   cacheTo: string[];
   cgroupParent: string;
   context: string;
+  contextSubdir: string;
   file: string;
   labels: string[];
   load: boolean;
@@ -73,6 +74,7 @@ export async function getInputs(defaultContext: string): Promise<Inputs> {
     cacheTo: await getInputList('cache-to', true),
     cgroupParent: core.getInput('cgroup-parent'),
     context: core.getInput('context') || defaultContext,
+    contextSubdir: core.getInput('context-subdir'),
     file: core.getInput('file'),
     labels: await getInputList('labels', true),
     load: core.getBooleanInput('load'),
@@ -97,7 +99,15 @@ export async function getArgs(inputs: Inputs, defaultContext: string, buildxVers
   let args: Array<string> = ['buildx'];
   args.push.apply(args, await getBuildArgs(inputs, defaultContext, buildxVersion));
   args.push.apply(args, await getCommonArgs(inputs, buildxVersion));
-  args.push(inputs.context);
+  let context: string = inputs.context;
+  if (inputs.contextSubdir) {
+    if (context == defaultContext) {
+      context = `${context}:${inputs.contextSubdir}`;
+    } else {
+      core.warning('"context-subdir" input is ignored when a "context" input is present');
+    }
+  }
+  args.push(context);
   return args;
 }
 


### PR DESCRIPTION
This is an alternative to #531, that PR implements the magic var which you described in https://github.com/docker/build-push-action/issues/460#issuecomment-917000054 .

This approach instead uses a new input `context-subdir` which gets appended to the context URL. This new input is ignored (with a warning) if the user also specifies a `context` input such (as a path). The potential benefit to this approach is that it might be a little easier for users than utilizing a magic var.

magic var:
```yaml
name: Build and push
id: docker_build
uses: docker/build-push-action@v2
with:
  push: true
  tags: user/app:latest
  context: {{defaultContext}}:docker
```

vs

new input:
```yaml
name: Build and push
id: docker_build
uses: docker/build-push-action@v2
with:
  push: true
  tags: user/app:latest
  context-subdir: docker
```

Closes #460
Closes #528