### PR TITLE
docs: update links and layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,29 @@ jobs:
         run: |
           docker image inspect myimage:latest
 
+  secret:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: ${{ inputs.buildx-version || env.BUILDX_VERSION }}
+          driver-opts: |
+            image=${{ inputs.buildkit-image || env.BUILDKIT_IMAGE }}
+      -
+        name: Build
+        uses: ./
+        with:
+          context: .
+          file: ./test/secret.Dockerfile
+          secrets: |
+            MYSECRET=foo
+            INVALID_SECRET=
+
   network:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 ## About
 
-GitHub Action to build and push Docker images with [Buildx](https://github.com/docker/buildx) with full support of the
-features provided by [Moby BuildKit](https://github.com/moby/buildkit) builder toolkit. This includes multi-platform
-build, secrets, remote cache, etc. and different builder deployment/namespacing options.
+GitHub Action to build and push Docker images with [Buildx](https://github.com/docker/buildx)
+with full support of the features provided by [Moby BuildKit](https://github.com/moby/buildkit)
+builder toolkit. This includes multi-platform build, secrets, remote cache, etc.
+and different builder deployment/namespacing options.
 
 ![Screenshot](.github/build-push-action.png)
 
@@ -30,23 +31,26 @@ ___
   * [Test your image before pushing it](docs/advanced/test-before-push.md)
   * [Named contexts](docs/advanced/named-contexts.md)
   * [Handle tags and labels](docs/advanced/tags-labels.md)
-  * [Update DockerHub repo description](docs/advanced/dockerhub-desc.md)
+  * [Update Docker Hub repo description](docs/advanced/dockerhub-desc.md)
 * [Customizing](#customizing)
   * [inputs](#inputs)
   * [outputs](#outputs)
 * [Troubleshooting](#troubleshooting)
-* [Keep up-to-date with GitHub Dependabot](#keep-up-to-date-with-github-dependabot)
+* [Contributing](#contributing)
 
 ## Usage
 
 In the examples below we are also using 3 other actions:
 
-* [`setup-buildx`](https://github.com/docker/setup-buildx-action) action will create and boot a builder using by 
-default the `docker-container` [builder driver](https://github.com/docker/buildx/blob/master/docs/reference/buildx_create.md#driver).
-This is **not required but recommended** using it to be able to build multi-platform images, export cache, etc.
-* [`setup-qemu`](https://github.com/docker/setup-qemu-action) action can be useful if you want
-to add emulation support with QEMU to be able to build against more platforms. 
-* [`login`](https://github.com/docker/login-action) action will take care to log in against a Docker registry.
+* [`setup-buildx`](https://github.com/docker/setup-buildx-action) action will
+  create and boot a builder using by default the [`docker-container` driver](https://docs.docker.com/build/building/drivers/docker-container/).
+  This is **not required but recommended** using it to be able to build
+  multi-platform images, export cache, etc.
+* [`setup-qemu`](https://github.com/docker/setup-qemu-action) action can be
+  useful if you want to add emulation support with QEMU to be able to build
+  against more platforms. 
+* [`login`](https://github.com/docker/login-action) action will take care to
+  log in against a Docker registry.
 
 ### Git context
 
@@ -54,7 +58,7 @@ By default, this action uses the [Git context](https://docs.docker.com/engine/re
 so you don't need to use the [`actions/checkout`](https://github.com/actions/checkout/)
 action to check out the repository as this will be done directly by [BuildKit](https://github.com/moby/buildkit).
 
-The git reference will be based on the [event that triggered your workflow](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)
+The git reference will be based on the [event that triggered your workflow](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
 and will result in the following context: `https://github.com/<owner>/<repo>.git#<ref>`.
 
 ```yaml
@@ -76,7 +80,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -123,10 +127,10 @@ to the default Git context:
 > Buildkit 0.8.2 at the moment, it does not support this feature. It's therefore
 > required to use the `setup-buildx-action` at the moment.
 
-Building from the current repository automatically uses the [GitHub Token](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token),
+Building from the current repository automatically uses the [GitHub Token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication),
 so it does not need to be passed. If you want to authenticate against another
 private repository, you have to use a [secret](docs/advanced/secrets.md) named
-`GIT_AUTH_TOKEN` to be able to authenticate against it with buildx:
+`GIT_AUTH_TOKEN` to be able to authenticate against it with Buildx:
 
 ```yaml
       -
@@ -163,7 +167,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -191,7 +195,7 @@ jobs:
 * [Test your image before pushing it](docs/advanced/test-before-push.md)
 * [Named contexts](docs/advanced/named-contexts.md)
 * [Handle tags and labels](docs/advanced/tags-labels.md)
-* [Update DockerHub repo description](docs/advanced/dockerhub-desc.md)
+* [Update Docker Hub repo description](docs/advanced/dockerhub-desc.md)
 
 ## Customizing
 
@@ -211,35 +215,35 @@ Following inputs can be used as `step.with` keys
 > tags: name/app:latest,name/app:1.0.0
 > ```
 
-| Name               | Type     | Description                                                                                                                                                                        |
-|--------------------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `add-hosts`        | List/CSV | List of [customs host-to-IP mapping](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) (e.g., `docker:10.180.0.1`)       |
-| `allow`            | List/CSV | List of [extra privileged entitlement](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#allow) (e.g., `network.host,security.insecure`)                 |
-| `builder`          | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action)                                                                                        |
-| `build-args`       | List     | List of [build-time variables](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#build-arg)                                                              |
-| `build-contexts`   | List     | List of additional [build contexts](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#build-context) (e.g., `name=path`)                                 |
-| `cache-from`       | List     | List of [external cache sources](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from) (e.g., `type=local,src=path/to/dir`)                      |
-| `cache-to`         | List     | List of [cache export destinations](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-to) (e.g., `type=local,dest=path/to/dir`)                    |
-| `cgroup-parent`    | String   | Optional [parent cgroup](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) for the container used in the build               |
-| `context`          | String   | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context))  |
-| `file`             | String   | Path to the Dockerfile. (default `{context}/Dockerfile`)                                                                                                                           |
-| `labels`           | List     | List of metadata for an image                                                                                                                                                      |
-| `load`             | Bool     | [Load](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#load) is a shorthand for `--output=type=docker` (default `false`)                               |
-| `network`          | String   | Set the networking mode for the `RUN` instructions during build                                                                                                                    |
-| `no-cache`         | Bool     | Do not use cache when building the image (default `false`)                                                                                                                         |
-| `no-cache-filters` | List/CSV | Do not cache specified stages                                                                                                                                                      |
-| `outputs`¹         | List     | List of [output destinations](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#output) (format: `type=local,dest=path`)                                 |
-| `platforms`        | List/CSV | List of [target platforms](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#platform) for build                                                         |
-| `pull`             | Bool     | Always attempt to pull all referenced images (default `false`)                                                                                                                     |
-| `push`             | Bool     | [Push](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#push) is a shorthand for `--output=type=registry` (default `false`)                             |
-| `secrets`          | List     | List of [secrets](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#secret) to expose to the build (e.g., `key=string`, `GIT_AUTH_TOKEN=mytoken`)        |
-| `secret-files`     | List     | List of [secret files](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#secret) to expose to the build (e.g., `key=filename`, `MY_SECRET=./secret.txt`) |
-| `shm-size`         | String   | Size of [`/dev/shm`](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-size-of-devshm---shm-size) (e.g., `2g`)                                          |
-| `ssh`              | List     | List of [SSH agent socket or keys](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#ssh) to expose to the build                                         |
-| `tags`             | List/CSV | List of tags                                                                                                                                                                       |
-| `target`           | String   | Sets the target stage to build                                                                                                                                                     |
-| `ulimit`           | List     | [Ulimit](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#-set-ulimits---ulimit) options (e.g., `nofile=1024:1024`)                                     |
-| `github-token`     | String   | GitHub Token used to authenticate against a repository for [Git context](#git-context) (default `${{ github.token }}`)                                                             |
+| Name               | Type     | Description                                                                                                                                                                       |
+|--------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `add-hosts`        | List/CSV | List of [customs host-to-IP mapping](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) (e.g., `docker:10.180.0.1`)      |
+| `allow`            | List/CSV | List of [extra privileged entitlement](https://docs.docker.com/engine/reference/commandline/buildx_build/#allow) (e.g., `network.host,security.insecure`)                         |
+| `builder`          | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action)                                                                                       |
+| `build-args`       | List     | List of [build-time variables](https://docs.docker.com/engine/reference/commandline/buildx_build/#build-arg)                                                                      |
+| `build-contexts`   | List     | List of additional [build contexts](https://docs.docker.com/engine/reference/commandline/buildx_build/#build-context) (e.g., `name=path`)                                         |
+| `cache-from`       | List     | List of [external cache sources](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-from) (e.g., `type=local,src=path/to/dir`)                              |
+| `cache-to`         | List     | List of [cache export destinations](https://docs.docker.com/engine/reference/commandline/buildx_build/#cache-to) (e.g., `type=local,dest=path/to/dir`)                            |
+| `cgroup-parent`    | String   | Optional [parent cgroup](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) for the container used in the build              |
+| `context`          | String   | Build's context is the set of files located in the specified [`PATH` or `URL`](https://docs.docker.com/engine/reference/commandline/build/) (default [Git context](#git-context)) |
+| `file`             | String   | Path to the Dockerfile. (default `{context}/Dockerfile`)                                                                                                                          |
+| `labels`           | List     | List of metadata for an image                                                                                                                                                     |
+| `load`             | Bool     | [Load](https://docs.docker.com/engine/reference/commandline/buildx_build/#load) is a shorthand for `--output=type=docker` (default `false`)                                       |
+| `network`          | String   | Set the networking mode for the `RUN` instructions during build                                                                                                                   |
+| `no-cache`         | Bool     | Do not use cache when building the image (default `false`)                                                                                                                        |
+| `no-cache-filters` | List/CSV | Do not cache specified stages                                                                                                                                                     |
+| `outputs`¹         | List     | List of [output destinations](https://docs.docker.com/engine/reference/commandline/buildx_build/#output) (format: `type=local,dest=path`)                                         |
+| `platforms`        | List/CSV | List of [target platforms](https://docs.docker.com/engine/reference/commandline/buildx_build/#platform) for build                                                                 |
+| `pull`             | Bool     | Always attempt to pull all referenced images (default `false`)                                                                                                                    |
+| `push`             | Bool     | [Push](https://docs.docker.com/engine/reference/commandline/buildx_build/#push) is a shorthand for `--output=type=registry` (default `false`)                                     |
+| `secrets`          | List     | List of [secrets](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build (e.g., `key=string`, `GIT_AUTH_TOKEN=mytoken`)                |
+| `secret-files`     | List     | List of [secret files](https://docs.docker.com/engine/reference/commandline/buildx_build/#secret) to expose to the build (e.g., `key=filename`, `MY_SECRET=./secret.txt`)         |
+| `shm-size`         | String   | Size of [`/dev/shm`](https://docs.docker.com/engine/reference/commandline/buildx_build/#shm-size) (e.g., `2g`)                                                                    |
+| `ssh`              | List     | List of [SSH agent socket or keys](https://docs.docker.com/engine/reference/commandline/buildx_build/#ssh) to expose to the build                                                 |
+| `tags`             | List/CSV | List of tags                                                                                                                                                                      |
+| `target`           | String   | Sets the target stage to build                                                                                                                                                    |
+| `ulimit`           | List     | [Ulimit](https://docs.docker.com/engine/reference/commandline/buildx_build/#ulimit) options (e.g., `nofile=1024:1024`)                                                            |
+| `github-token`     | String   | GitHub Token used to authenticate against a repository for [Git context](#git-context) (default `${{ github.token }}`)                                                            |
 
 > **Note**
 >
@@ -249,28 +253,17 @@ Following inputs can be used as `step.with` keys
 
 Following outputs are available
 
-| Name       | Type    | Description                             |
-|------------|---------|-----------------------------------------|
-| `imageid`  | String  | Image ID                                |
-| `digest`   | String  | Image digest                            |
-| `metadata` | JSON    | Build result metadata                   |
+| Name       | Type    | Description           |
+|------------|---------|-----------------------|
+| `imageid`  | String  | Image ID              |
+| `digest`   | String  | Image digest          |
+| `metadata` | JSON    | Build result metadata |
 
 ## Troubleshooting
 
 See [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 
-## Keep up-to-date with GitHub Dependabot
+## Contributing
 
-Since [Dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot)
-has [native GitHub Actions support](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem),
-to enable it on your GitHub repo all you need to do is add the `.github/dependabot.yml` file:
-
-```yaml
-version: 2
-updates:
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-```
+Want to contribute? Awesome! You can find information about contributing to
+this project in the [CONTRIBUTING.md](/.github/CONTRIBUTING.md)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,7 +16,7 @@ While pushing to a registry, you may encounter these kinds of issues:
 * `unexpected response: 401 Unauthorized`
 
 These issues are not directly related to this action but are rather linked to
-[buildx](https://github.com/docker/buildx), [buildkit](https://github.com/moby/buildkit),
+[Buildx](https://github.com/docker/buildx), [BuildKit](https://github.com/moby/buildkit),
 [containerd](https://github.com/containerd/containerd) or the registry on which
 you're pushing your image. The quality of error message depends on the registry
 and are usually not very informative.
@@ -29,7 +29,7 @@ action step and attach BuildKit container logs to your issue.
 ### With containerd
 
 Next you can test pushing with [containerd action](https://github.com/crazy-max/ghaction-setup-containerd)
-using the following workflow. If it works then open an issue on [buildkit](https://github.com/moby/buildkit)
+using the following workflow. If it works then open an issue on [BuildKit](https://github.com/moby/buildkit)
 repository.
 
 ```yaml

--- a/__tests__/buildx.test.ts
+++ b/__tests__/buildx.test.ts
@@ -137,8 +137,7 @@ describe('getSecret', () => {
       }
       expect(true).toBe(!invalid);
       expect(secret).toEqual(`id=${exKey},src=${tmpNameSync}`);
-      const secretValue = await fs.readFileSync(tmpNameSync, 'utf-8');
-      expect(secretValue).toEqual(exValue);
+      expect(fs.readFileSync(tmpNameSync, 'utf-8')).toEqual(exValue);
     } catch (err) {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(true).toBe(invalid);

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker/dockerfile:1
 
 ARG NODE_VERSION=16
 ARG DOCKER_VERSION=20.10.13

--- a/docs/advanced/cache.md
+++ b/docs/advanced/cache.md
@@ -6,11 +6,14 @@
   * [Cache backend API](#cache-backend-api)
   * [Local cache](#local-cache)
 
-> More info about cache on [BuildKit](https://github.com/moby/buildkit#export-cache) and [Buildx](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from) repositories.
+> **Note**
+>
+> See [our guide](https://github.com/docker/buildx/blob/master/docs/guides/cache/index.md)
+> for more details about cache storage backends.
 
 ## Inline cache
 
-In most cases you want to use the [`type=inline` cache exporter](https://github.com/moby/buildkit#inline-push-image-and-cache-together).
+In most cases you want to use the [`type=inline` cache exporter](https://github.com/docker/buildx/blob/master/docs/guides/cache/inline.md).
 However, note that the `inline` cache exporter only supports `min` cache mode. To enable `max` cache mode, push the
 image and the cache separately by using the `registry` cache exporter as shown in the [next example](#registry-cache).
 
@@ -33,7 +36,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -52,7 +55,7 @@ jobs:
 ## Registry cache
 
 You can import/export cache from a cache manifest or (special) image configuration on the registry with the
-[`type=registry` cache exporter](https://github.com/moby/buildkit/tree/master#registry-push-image-and-cache-separately).
+[`type=registry` cache exporter](https://github.com/docker/buildx/blob/master/docs/guides/cache/registry.md).
 
 ```yaml
 name: ci
@@ -73,7 +76,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -93,15 +96,17 @@ jobs:
 
 ### Cache backend API
 
-> :test_tube: This cache exporter is considered EXPERIMENTAL until further notice. Please provide feedback on
-> [BuildKit repository](https://github.com/moby/buildkit) if you encounter any issues.
+> **Warning**
+>
+> This cache exporter is considered EXPERIMENTAL until further notice. Please
+> provide feedback on [BuildKit repository](https://github.com/moby/buildkit)
+> if you encounter any issues.
 
-Since [buildx 0.6.0](https://github.com/docker/buildx/releases/tag/v0.6.0) and [BuildKit 0.9.0](https://github.com/moby/buildkit/releases/tag/v0.9.0),
-you can use the [`type=gha` cache exporter](https://github.com/moby/buildkit/tree/master#github-actions-cache-experimental).
-
-GitHub Actions cache exporter backend uses the [GitHub Cache API](https://github.com/tonistiigi/go-actions-cache/blob/master/api.md)
-to fetch and upload cache blobs. That's why this type of cache should be exclusively used in a GitHub Action workflow
-as the `url` (`$ACTIONS_CACHE_URL`) and `token` (`$ACTIONS_RUNTIME_TOKEN`) attributes are populated when a workflow
+[GitHub Actions cache exporter](https://github.com/docker/buildx/blob/master/docs/guides/cache/gha.md)
+backend uses the [GitHub Cache API](https://github.com/tonistiigi/go-actions-cache/blob/master/api.md)
+to fetch and upload cache blobs. That's why this type of cache should be
+exclusively used in a GitHub Action workflow as the `url` (`$ACTIONS_CACHE_URL`)
+and `token` (`$ACTIONS_RUNTIME_TOKEN`) attributes are populated when a workflow
 is started.
 
 ```yaml
@@ -123,7 +128,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -141,11 +146,13 @@ jobs:
 
 ### Local cache
 
-> :warning: At the moment caches are copied over the existing cache so it [keeps growing](https://github.com/docker/build-push-action/issues/252).
-> The `Move cache` step is used as a temporary fix (see https://github.com/moby/buildkit/issues/1896).
+> **Warning**
+>
+> At the moment caches are copied over the existing cache, so it [keeps growing](https://github.com/docker/build-push-action/issues/252).
+> The `Move cache` step is used as a workaround (see [moby/buildkit#1896](https://github.com/moby/buildkit/issues/1896) for more info).
 
-You can also leverage [GitHub cache](https://docs.github.com/en/actions/configuring-and-managing-workflows/caching-dependencies-to-speed-up-workflows)
-using [actions/cache](https://github.com/actions/cache) and [`type=local` cache exporter](https://github.com/moby/buildkit#local-directory-1)
+You can also leverage [GitHub cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
+using the [actions/cache](https://github.com/actions/cache) and [`type=local` cache exporter](https://github.com/docker/buildx/blob/master/docs/guides/cache/local.md)
 with this action:
 
 ```yaml
@@ -175,7 +182,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/advanced/dockerhub-desc.md
+++ b/docs/advanced/dockerhub-desc.md
@@ -1,7 +1,7 @@
-# Update DockerHub repo description
+# Update Docker Hub repo description
 
-You can update the [DockerHub repository description](https://docs.docker.com/docker-hub/repos/) using
-a third party action called [DockerHub Description](https://github.com/peter-evans/dockerhub-description)
+You can update the [Docker Hub repository description](https://docs.docker.com/docker-hub/repos/)
+using a third party action called [Docker Hub Description](https://github.com/peter-evans/dockerhub-description)
 with this action:
 
 ```yaml
@@ -26,7 +26,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/advanced/local-registry.md
+++ b/docs/advanced/local-registry.md
@@ -1,6 +1,7 @@
 # Local registry
 
-For testing purposes you may need to create a [local registry](https://hub.docker.com/_/registry) to push images into:
+For testing purposes you may need to create a [local registry](https://hub.docker.com/_/registry)
+to push images into:
 
 ```yaml
 name: ci

--- a/docs/advanced/multi-platform.md
+++ b/docs/advanced/multi-platform.md
@@ -1,10 +1,14 @@
 # Multi-platform image
 
-You can build multi-platform images using the [`platforms` input](../../README.md#inputs) as described below.
+You can build [multi-platform images](https://docs.docker.com/build/building/multi-platform/)
+using the [`platforms` input](../../README.md#inputs) as described below.
 
-> :bulb: List of available platforms will be displayed and available through our [setup-buildx](https://github.com/docker/setup-buildx-action#about) action.
-
-> :bulb: If you want support for more platforms, you can use QEMU with our [setup-qemu](https://github.com/docker/setup-qemu-action) action.
+> **Note**
+>
+> * List of available platforms will be displayed and available through our
+>   [setup-buildx](https://github.com/docker/setup-buildx-action#about) action.
+> * If you want support for more platforms, you can use QEMU with our
+>   [setup-qemu](https://github.com/docker/setup-qemu-action) action.
 
 ```yaml
 name: ci
@@ -28,7 +32,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/advanced/named-contexts.md
+++ b/docs/advanced/named-contexts.md
@@ -7,6 +7,9 @@ Dockerfile defines a stage with the same name it is overwritten.
 This can be useful with GitHub Actions to reuse results from other builds or
 pin an image to a spcific tag in your workflow.
 
+* [Pin image to a specific tag](#pin-image-to-a-specific-tag)
+* [Usage of the built image in other build steps](#usage-of-the-built-image-in-other-build-steps)
+
 ## Pin image to a specific tag
 
 Replace `alpine:latest` with a pinned one:

--- a/docs/advanced/push-multi-registries.md
+++ b/docs/advanced/push-multi-registries.md
@@ -1,12 +1,8 @@
 # Push to multi-registries
 
-* [Docker Hub and GHCR](#docker-hub-and-ghcr)
-
-## Docker Hub and GHCR
-
-The following workflow will connect you to [DockerHub](https://github.com/docker/login-action#dockerhub)
-and [GitHub Container Registry](https://github.com/docker/login-action#github-container-registry) and push the
-image to these registries.
+The following workflow will connect you to [Docker Hub](https://github.com/docker/login-action#dockerhub)
+and [GitHub Container Registry](https://github.com/docker/login-action#github-container-registry)
+and push the image to these registries:
 
 ```yaml
 name: ci
@@ -30,7 +26,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/advanced/secrets.md
+++ b/docs/advanced/secrets.md
@@ -1,20 +1,19 @@
 # Secrets
 
-In the following example we will expose and use the [GITHUB_TOKEN secret](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret)
+In the following example we will expose and use the [GITHUB_TOKEN secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret)
 as provided by GitHub in your workflow.
 
 First let's create our `Dockerfile` to use our secret:
 
-```Dockerfile
-#syntax=docker/dockerfile:1.2
-
+```dockerfile
+# syntax=docker/dockerfile:1
 FROM alpine
 RUN --mount=type=secret,id=github_token \
   cat /run/secrets/github_token
 ```
 
-As you can see we have named our secret `github_token`. Here is the workflow you can use to expose this secret using
-the [`secrets` input](../../README.md#inputs):
+As you can see we have named our secret `github_token`. Here is the workflow
+you can use to expose this secret using the [`secrets` input](../../README.md#inputs):
 
 ```yaml
 name: ci
@@ -48,14 +47,17 @@ jobs:
             "github_token=${{ secrets.GITHUB_TOKEN }}"
 ```
 
-> :bulb: You can also expose a secret file to the build with [`secret-files`](../../README.md#inputs) input:
+> **Note**
+>
+> You can also expose a secret file to the build with the [`secret-files`](../../README.md#inputs) input:
 > ```yaml
 > secret-files: |
 >   "MY_SECRET=./secret.txt"
 > ```
 
-If you're using [GitHub secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) and need to handle
-multi-line value, you will need to place the key-value pair between quotes:
+If you're using [GitHub secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+and need to handle multi-line value, you will need to place the key-value pair
+between quotes:
 
 ```yaml
 secrets: |
@@ -72,13 +74,15 @@ secrets: |
   "JSON_SECRET={""key1"":""value1"",""key2"":""value2""}"
 ```
 
-| Key                | Value                                            |
-|--------------------|--------------------------------------------------|
-| `MYSECRET`         | `***********************` |
-| `GIT_AUTH_TOKEN`   | `abcdefghi,jklmno=0123456789` |
-| `MYSECRET`         | `aaaaaaaa\nbbbbbbb\nccccccccc` |
-| `FOO`              | `bar` |
-| `EMPTYLINE`        | `aaaa\n\nbbbb\nccc` |
+| Key                | Value                               |
+|--------------------|-------------------------------------|
+| `MYSECRET`         | `***********************`           |
+| `GIT_AUTH_TOKEN`   | `abcdefghi,jklmno=0123456789`       |
+| `MYSECRET`         | `aaaaaaaa\nbbbbbbb\nccccccccc`      |
+| `FOO`              | `bar`                               |
+| `EMPTYLINE`        | `aaaa\n\nbbbb\nccc`                 |
 | `JSON_SECRET`      | `{"key1":"value1","key2":"value2"}` |
 
-> :bulb: All quote signs need to be doubled for escaping.
+> **Note**
+>
+> All quote signs need to be doubled for escaping.

--- a/docs/advanced/share-image-jobs.md
+++ b/docs/advanced/share-image-jobs.md
@@ -1,8 +1,10 @@
 # Share built image between jobs
 
-As each job is isolated in its own runner you cannot use your built image between jobs (except for [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)).
-However, you can [pass data between jobs in a workflow](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow)
-using the [actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/download-artifact](https://github.com/actions/download-artifact)
+As each job is isolated in its own runner you cannot use your built image
+between jobs (except for [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)).
+However, you can [pass data between jobs in a workflow](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow)
+using the [actions/upload-artifact](https://github.com/actions/upload-artifact)
+and [actions/download-artifact](https://github.com/actions/download-artifact)
 actions:
 
 ```yaml

--- a/docs/advanced/tags-labels.md
+++ b/docs/advanced/tags-labels.md
@@ -1,8 +1,9 @@
 # Handle tags and labels
 
 If you want an "automatic" tag management and [OCI Image Format Specification](https://github.com/opencontainers/image-spec/blob/master/annotations.md)
-for labels, you can do it in a dedicated step. The following workflow will use the [Docker metadata action](https://github.com/docker/metadata-action)
-to handle tags and labels based on GitHub actions events and Git metadata.
+for labels, you can do it in a dedicated step. The following workflow will use
+the [Docker metadata action](https://github.com/docker/metadata-action) to
+handle tags and labels based on GitHub actions events and Git metadata:
 
 ```yaml
 name: ci
@@ -51,7 +52,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:

--- a/docs/advanced/test-before-push.md
+++ b/docs/advanced/test-before-push.md
@@ -33,7 +33,7 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -59,6 +59,8 @@ jobs:
           tags: ${{ env.TEST_TAG }}
 ```
 
-> :bulb: Build time will not be increased with this workflow because internal
-> cache for `linux/amd64` will be used from previous step on `Build and push`
-> step so only `linux/arm64` will be actually built.
+> **Note**
+>
+> Build time will not be increased with this workflow because internal cache
+> for `linux/amd64` will be used from previous step on `Build and push` step
+> so only `linux/arm64` will be actually built.

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,3 +1,3 @@
+# syntax=docker/dockerfile:1
 FROM alpine
-
 RUN echo "Hello world!"

--- a/test/addhost.Dockerfile
+++ b/test/addhost.Dockerfile
@@ -1,2 +1,3 @@
+# syntax=docker/dockerfile:1
 FROM busybox
 RUN cat /etc/hosts

--- a/test/buildcontext.Dockerfile
+++ b/test/buildcontext.Dockerfile
@@ -1,3 +1,3 @@
-# syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile:1
 FROM alpine
 RUN cat /etc/*release

--- a/test/cgroup.Dockerfile
+++ b/test/cgroup.Dockerfile
@@ -1,2 +1,3 @@
+# syntax=docker/dockerfile:1
 FROM alpine
 RUN cat /proc/self/cgroup

--- a/test/multi-sudo.Dockerfile
+++ b/test/multi-sudo.Dockerfile
@@ -1,9 +1,8 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:alpine AS build
-
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
-
 RUN apk --update --no-cache add \
     shadow \
     sudo \
@@ -17,6 +16,5 @@ RUN sudo chown buildx. /log
 USER root
 
 FROM alpine
-
 COPY --from=build /log /log
 RUN ls -al /log

--- a/test/multi.Dockerfile
+++ b/test/multi.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM --platform=$BUILDPLATFORM golang:alpine AS build
 
 ARG TARGETPLATFORM

--- a/test/nocachefilter.Dockerfile
+++ b/test/nocachefilter.Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM busybox AS base
 RUN echo "Hello world!" > /hello
 

--- a/test/secret.Dockerfile
+++ b/test/secret.Dockerfile
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1
+FROM busybox
+RUN --mount=type=secret,id=MYSECRET \
+  echo "MYSECRET=$(cat /run/secrets/MYSECRET)"

--- a/test/shmsize.Dockerfile
+++ b/test/shmsize.Dockerfile
@@ -1,2 +1,3 @@
+# syntax=docker/dockerfile:1
 FROM busybox
 RUN mount | grep /dev/shm

--- a/test/ulimit.Dockerfile
+++ b/test/ulimit.Dockerfile
@@ -1,2 +1,3 @@
+# syntax=docker/dockerfile:1
 FROM busybox
 RUN ulimit -a


### PR DESCRIPTION
* update links to docs website and GitHub documentation
* copy between registries with buildx (supported since 0.9.0)
* link to new [cache guide](https://github.com/docker/buildx/tree/master/docs/guides/cache) (to be changed when added to docs website, cc @jedevc @dvdksn)