### PR TITLE
fix: incorrect yaml in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the examples below we are also using 3 other actions:
   multi-platform images, export cache, etc.
 * [`setup-qemu`](https://github.com/docker/setup-qemu-action) action can be
   useful if you want to add emulation support with QEMU to be able to build
-  against more platforms. 
+  against more platforms.
 * [`login`](https://github.com/docker/login-action) action will take care to
   log in against a Docker registry.
 
@@ -73,20 +73,19 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -105,13 +104,12 @@ expression `{{defaultContext}}`. Here we can use it to provide a subdirectory
 to the default Git context:
 
 ```yaml
-      -
         # Setting up Docker Buildx with docker-container driver is required
         # at the moment to be able to use a subdirectory with Git context
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:mysubdir"
@@ -133,8 +131,7 @@ private repository, you have to use a [secret](docs/advanced/secrets.md) named
 `GIT_AUTH_TOKEN` to be able to authenticate against it with Buildx:
 
 ```yaml
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -157,23 +154,23 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,9 +1,10 @@
 # Troubleshooting
 
-* [Cannot push to a registry](#cannot-push-to-a-registry)
-  * [BuildKit container logs](#buildkit-container-logs)
-  * [With containerd](#with-containerd)
-* [`repository name must be lowercase`](#repository-name-must-be-lowercase)
+- [Troubleshooting](#troubleshooting)
+  - [Cannot push to a registry](#cannot-push-to-a-registry)
+    - [BuildKit container logs](#buildkit-container-logs)
+    - [With containerd](#with-containerd)
+  - [`repository name must be lowercase`](#repository-name-must-be-lowercase)
 
 ## Cannot push to a registry
 
@@ -42,34 +43,33 @@ jobs:
   containerd:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
-      -
-        name: Set up containerd
+
+      - name: Set up containerd
         uses: crazy-max/ghaction-setup-containerd@v2
-      -
-        name: Build Docker image
+
+      - name: Build Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           tags: docker.io/user/app:latest
           outputs: type=oci,dest=/tmp/image.tar
-      -
-        name: Import image in containerd
+
+      - name: Import image in containerd
         run: |
           sudo ctr i import --base-name docker.io/user/app --digests --all-platforms /tmp/image.tar
-      -
-        name: Push image with containerd
+
+      - name: Push image with containerd
         run: |
           sudo ctr --debug i push --user "${{ secrets.DOCKER_USERNAME }}:${{ secrets.DOCKER_PASSWORD }}" docker.io/user/app:latest
 ```

--- a/docs/advanced/cache.md
+++ b/docs/advanced/cache.md
@@ -29,20 +29,16 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -69,20 +65,16 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -121,20 +113,16 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -167,28 +155,23 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Cache Docker layers
+      - name: Cache Docker layers
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/docs/advanced/copy-between-registries.md
+++ b/docs/advanced/copy-between-registries.md
@@ -16,30 +16,25 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - 
+      -
         name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -48,8 +43,7 @@ jobs:
           tags: |
             user/app:latest
             user/app:1.0.0
-      -
-        name: Push image to GHCR
+      - name: Push image to GHCR
         run: |
           docker buildx imagetools create \
             --tag ghcr.io/user/app:latest \

--- a/docs/advanced/dockerhub-desc.md
+++ b/docs/advanced/dockerhub-desc.md
@@ -16,30 +16,24 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
           tags: user/app:latest
-      -
-        name: Update repo description
+      - name: Update repo description
         uses: peter-evans/dockerhub-description@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docs/advanced/export-docker.md
+++ b/docs/advanced/export-docker.md
@@ -15,21 +15,17 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           context: .
           load: true
           tags: myimage:latest
-      -
-        name: Inspect
+      - name: Inspect
         run: |
           docker image inspect myimage:latest
 ```

--- a/docs/advanced/isolated-builders.md
+++ b/docs/advanced/isolated-builders.md
@@ -12,8 +12,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
       -
         uses: docker/setup-buildx-action@v2
@@ -21,21 +20,17 @@ jobs:
       -
         uses: docker/setup-buildx-action@v2
         id: builder2
-      -
-        name: Builder 1 name
+      - name: Builder 1 name
         run: echo ${{ steps.builder1.outputs.name }}
-      -
-        name: Builder 2 name
+      - name: Builder 2 name
         run: echo ${{ steps.builder2.outputs.name }}
-      -
-        name: Build against builder1
+      - name: Build against builder1
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.builder1.outputs.name }}
           context: .
           target: mytarget1
-      -
-        name: Build against builder2
+      - name: Build against builder2
         uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.builder2.outputs.name }}

--- a/docs/advanced/local-registry.md
+++ b/docs/advanced/local-registry.md
@@ -20,26 +20,21 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
-      -
-        name: Build and push to local registry
+      - name: Build and push to local registry
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
           tags: localhost:5000/name/app:latest
-      -
-        name: Inspect
+      - name: Inspect
         run: |
           docker buildx imagetools inspect localhost:5000/name/app:latest
 ```

--- a/docs/advanced/multi-platform.md
+++ b/docs/advanced/multi-platform.md
@@ -22,23 +22,18 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/docs/advanced/named-contexts.md
+++ b/docs/advanced/named-contexts.md
@@ -32,14 +32,11 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -74,21 +71,17 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build base image
+      - name: Build base image
         uses: docker/build-push-action@v3
         with:
           context: base
           load: true
           tags: my-base-image:latest
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/docs/advanced/push-multi-registries.md
+++ b/docs/advanced/push-multi-registries.md
@@ -16,30 +16,24 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/docs/advanced/secrets.md
+++ b/docs/advanced/secrets.md
@@ -27,17 +27,13 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -68,7 +64,7 @@ secrets: |
   ccccccccc"
   FOO=bar
   "EMPTYLINE=aaaa
-  
+
   bbbb
   ccc"
   "JSON_SECRET={""key1"":""value1"",""key2"":""value2""}"

--- a/docs/advanced/share-image-jobs.md
+++ b/docs/advanced/share-image-jobs.md
@@ -19,21 +19,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Build and export
+      - name: Build and export
         uses: docker/build-push-action@v3
         with:
           context: .
           tags: myimage:latest
           outputs: type=docker,dest=/tmp/myimage.tar
-      -
-        name: Upload artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: myimage
@@ -43,17 +39,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Download artifact
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: myimage
           path: /tmp
-      -
-        name: Load image
+      - name: Load image
         run: |
           docker load --input /tmp/myimage.tar
           docker image ls -a

--- a/docs/advanced/tags-labels.md
+++ b/docs/advanced/tags-labels.md
@@ -24,11 +24,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Docker meta
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -45,29 +43,24 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GHCR
+      - name: Login to GHCR
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/docs/advanced/test-before-push.md
+++ b/docs/advanced/test-before-push.md
@@ -24,34 +24,27 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
-      -
-        name: Set up QEMU
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and export to Docker
+      - name: Build and export to Docker
         uses: docker/build-push-action@v3
         with:
           context: .
           load: true
           tags: ${{ env.TEST_TAG }}
-      -
-        name: Test
+      - name: Test
         run: |
           docker run --rm ${{ env.TEST_TAG }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
Fix invalid YAML in documentation.

Previous the name key for each section had it's key identifier incorrectly on the previous line.

This may seem trivial, but if users had copy/pasted the examples given their YAML would be incorrectly formatted.