### PR TITLE
test: move envs to jest config

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -66,10 +66,6 @@ FROM docker:${DOCKER_VERSION} as docker
 FROM docker/buildx-bin:${BUILDX_VERSION} as buildx
 
 FROM deps AS test
-ENV RUNNER_TEMP=/tmp/github_runner
-ENV RUNNER_TOOL_CACHE=/tmp/github_tool_cache
-ENV GITHUB_REPOSITORY=docker/build-push-action
-ENV GITHUB_RUN_ID=123456789
 RUN --mount=type=bind,target=.,rw \
   --mount=type=cache,target=/src/node_modules \
   --mount=type=bind,from=docker,source=/usr/local/bin/docker,target=/usr/bin/docker \

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,15 @@
+process.env = Object.assign({}, process.env, {
+  RUNNER_TEMP: '/tmp/github_runner',
+  RUNNER_TOOL_CACHE: '/tmp/github_tool_cache',
+  GITHUB_REPOSITORY: 'docker/build-push-action',
+  GITHUB_RUN_ID: '123456789'
+}) as {
+  [key: string]: string;
+};
+
 module.exports = {
   clearMocks: false,
+  testEnvironment: 'node',
   moduleFileExtensions: ['js', 'ts'],
   setupFiles: ['dotenv/config'],
   testMatch: ['**/*.test.ts'],


### PR DESCRIPTION
Move env vars for testing in jest configuration otherwise running tests outside the container (`yarn run test`) would not work.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>