### PR TITLE
e2e: remove harbor

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,11 +70,6 @@ jobs:
             slug: officialgithubactions.azurecr.io/test-docker-action
             username_secret: AZURE_CLIENT_ID
             password_secret: AZURE_CLIENT_SECRET
-          -
-            registry: demo.goharbor.io
-            slug: demo.goharbor.io/build-push-action/test-docker-action
-            username_secret: HARBOR_USERNAME
-            password_secret: HARBOR_TOKEN
     steps:
       -
         name: Checkout


### PR DESCRIPTION
https://github.com/docker/build-push-action/actions/runs/4104121835/jobs/7079186952#step:6:25 :disappointed:

```
Logging into demo.goharbor.io...
Error: Error response from daemon: Get "https://demo.goharbor.io/v2/": unauthorized: authentication required
```

Misread the [disclaimer](https://goharbor.io/docs/1.10/install-config/demo-server/). Server is reset every 2 days. Thinking it was just content, not everything though. So let's just remove it while waiting for a dedicated instance.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>