### PR TITLE
e2e: enable buildkit container logs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,6 +88,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           version: ${{ inputs.buildx-version || env.BUILDX_VERSION }}
+          buildkitd-flags: --debug
           driver-opts: |
             image=${{ inputs.buildkit-image || env.BUILDKIT_IMAGE }}
       -


### PR DESCRIPTION
In trying to debug https://github.com/docker/build-push-action/actions/runs/4124011267/jobs/7122739357, it would be useful to see the buildkit logs :eyes: (as well as for future failures)