### PR TITLE
ci: add artifactory container registry to test against

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,6 +99,13 @@ jobs:
             password_secret: QUAY_TOKEN
             type: remote
           -
+            name: Artifactory
+            registry: buildkitghactiontests.jfrog.io
+            slug: buildkitghactiontests.jfrog.io/ghactiontest/test-docker-action
+            username_secret: ARTIFACTORY_USERNAME
+            password_secret: ARTIFACTORY_TOKEN
+            type: remote
+          -
             name: Harbor
             id: harbor
             type: local


### PR DESCRIPTION
The artifactory container registry is configured to accept schema 2 manifests.

I have credentials for the registry, but don't have permissions to modify secrets for the GitHub actions in the repo.