### PR TITLE
feat: allow csv usage in labels - fixes #873

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -52,7 +52,7 @@ export async function getInputs(): Promise<Inputs> {
     cgroupParent: core.getInput('cgroup-parent'),
     context: core.getInput('context') || Context.gitContext(),
     file: core.getInput('file'),
-    labels: Util.getInputList('labels', {ignoreComma: true}),
+    labels: Util.getInputList('labels'),
     load: core.getBooleanInput('load'),
     network: core.getInput('network'),
     noCache: core.getBooleanInput('no-cache'),


### PR DESCRIPTION
This PR allows the usage of comma separated inputs for labels when using composite or reusable inputs:

```yml
      - name: Build and push
        uses: docker/build-push-action@v4
        with:
          push: true
          tags: user/app:latest
          labels: ${{ inputs.build-labels }}
          # Where build-labels is:
          # build-labels: Foo=Bar,Bar=Baz
```

Fixes #873