### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
       -
         name: Stop docker
         run: |
-          sudo systemctl stop docker
+          sudo systemctl stop docker docker.socket
       -
         name: Build
         id: docker_build
@@ -900,9 +900,13 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Uninstall moby cli
+        name: Uninstall docker cli
         run: |
-          sudo apt-get purge -y moby-cli moby-buildx
+          if dpkg -s "docker-ce" >/dev/null 2>&1; then
+            sudo dpkg -r --force-depends docker-ce-cli docker-buildx-plugin
+          else
+            sudo apt-get purge -y moby-cli moby-buildx
+          fi
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
related to: https://github.com/docker/build-push-action/actions/runs/6071970357/job/16471074937#step:5:29

![image](https://github.com/docker/build-push-action/assets/1951866/40269dfa-fa34-4b1e-a188-d10049fc12f8)

docker-ce packages are now installed on GitHub Runners. Same as https://github.com/docker/setup-buildx-action/commit/93b8ecaa2c1900a3605b90629b56d2208bf1d41f