### PR TITLE
e2e: fix .docker folder perms

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -75,6 +75,7 @@ jobs:
         if: inputs.type == 'local'
         run: |
           sudo -E bash ./.github/e2e/${{ inputs.id }}/install.sh
+          sudo chown $(id -u):$(id -g) -R ~/.docker
       -
         name: Docker meta
         id: meta


### PR DESCRIPTION
![image](https://github.com/docker/build-push-action/assets/1951866/d8dbd3f9-93e6-4463-8cfb-91540909b0ca)

First time seen in https://github.com/docker/build-push-action/actions/runs/6324380195/job/17173793318#step:9:132 (2 weeks ago) when installing Nexus or Harbor.

Looks related to runner image `20230924.1.0`: https://github.com/actions/runner-images/blob/ubuntu22/20230924.1/images/linux/Ubuntu2204-Readme.md

![image](https://github.com/docker/build-push-action/assets/1951866/fbe56d41-647b-4a3b-a1e6-d553659fbcca)

Was working fine with `20230917.1.0` in the same pipeline: https://github.com/docker/build-push-action/actions/runs/6324380195/job/17173792127#step:1:9

![image](https://github.com/docker/build-push-action/assets/1951866/de321a88-ecf5-41c5-988e-ab0cd753265c)
