### PR TITLE
upgrade actions/checkout to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -45,7 +45,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
**Description**:
Thanks for your work. The actions/checkout has been [released to v4](https://github.com/actions/checkout/releases/tag/v4.0.0), I have updated README to use it.