### PR TITLE
ci(e2e): fix artifactory slug

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,7 +91,7 @@ jobs:
           -
             name: Artifactory
             registry: infradock.jfrog.io
-            slug: infradock.jfrog.io/test-ghaction
+            slug: infradock.jfrog.io/test-ghaction/build-push-action
             username_secret: ARTIFACTORY_USERNAME
             password_secret: ARTIFACTORY_TOKEN
             type: remote


### PR DESCRIPTION
related to https://github.com/docker/build-push-action/actions/runs/9029359754/job/24811564712#step:11:397

```
ERROR: failed to solve: failed to push infradock.jfrog.io/test-ghaction:master: unexpected status from POST request to https://infradock.jfrog.io/v2/test-ghaction/blobs/uploads/: 404 Not Found
```