### PR TITLE
init buildkit-5561 workflow

### DIFF
--- a/.github/workflows/buildkit-5561.yml
+++ b/.github/workflows/buildkit-5561.yml
@@ -1,0 +1,16 @@
+name: buildkit-5561
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4


### PR DESCRIPTION
relates to https://github.com/moby/buildkit/issues/5561#issuecomment-2520392156

init workflow on default branch so other branches in this repo can run it: https://github.com/docker/build-push-action/tree/test-buildkit-5561