### PR TITLE
Clarify .dockerignore usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
 ```
 
 Be careful because **any file mutation in the steps that precede the build step
-will be ignored, including processing of the `.dockerignore` file** since
+will be ignored. Additionally the `.dockerignore` file is not used and can only be utilized by using path context.** since
 the context is based on the Git reference. However, you can use the
 [Path context](#path-context) using the [`context` input](#inputs) alongside
 the [`actions/checkout`](https://github.com/actions/checkout/) action to remove


### PR DESCRIPTION
The previous instructions made me think mutation of the .dockerignore file was not supported with the git context, but the the basic .dockerignore was supported (not the case). Just trying to improve the doc so it is more clear. 