### PR TITLE
e2e: remove GCR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,13 +68,6 @@ jobs:
             password_secret: GAR_JSON_KEY
             type: remote
           -
-            name: Google Container Registry
-            registry: gcr.io
-            slug: gcr.io/sandbox-298914/test-docker-action
-            username_secret: GCR_USERNAME
-            password_secret: GCR_JSON_KEY
-            type: remote
-          -
             name: Azure Container Registry
             registry: officialgithubactions.azurecr.io
             slug: officialgithubactions.azurecr.io/test-docker-action


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/actions/runs/15042134376/job/42276145265#step:11:397

```
#40 exporting to image
#40 pushing layers 1.3s done
#40 ERROR: failed to push gcr.io/sandbox-298914/test-docker-action:gh-runid-15042134376: failed to authorize: failed to fetch oauth token: unexpected status from GET request to https://gcr.io/v2/token?scope=repository%3Asandbox-298914%2Ftest-docker-action%3Apull%2Cpush&service=gcr.io: 412 Precondition Failed
```

GCR was sunset on March 18, 2025: https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

> Container Registry is deprecated. Effective March 18, 2025, Container Registry is shut down and writing images to Container Registry is unavailable.