### PR TITLE
docs: update checkout action to v5 in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Updates the README workflow examples to use actions/checkout@v5 instead of @v4.