### PR TITLE
chore: upgrade nodejs from 20 to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,6 +121,6 @@ outputs:
     description: 'Build result metadata'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
   post: 'dist/index.js'

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 
 FROM node:${NODE_VERSION}-alpine AS base
 RUN apk add --no-cache cpio findutils git

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@eslint/compat": "^2.0.0",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@types/node": "^20.19.27",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^8.50.0",
     "@typescript-eslint/parser": "^8.50.0",
     "@vercel/ncc": "^0.38.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,12 +2303,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.19.27":
-  version: 20.19.27
-  resolution: "@types/node@npm:20.19.27"
+"@types/node@npm:^24.0.0":
+  version: 24.10.9
+  resolution: "@types/node@npm:24.10.9"
   dependencies:
-    undici-types: ~6.21.0
-  checksum: d19cf59bc6de483d25d822c7a0c99ccff58eba7ff36331e71c0aad78b817faa69781dcac1b70e6b6b037de2c6d08aca7c543140087482f50a4a72423c0c18de8
+    undici-types: ~7.16.0
+  checksum: ee6e0a13b286c4cec32c29e2a7d862345660f6720f805315733f7802f6ece45d23fa0d4baee56276e48e62c4b7c3d335e5f40955179afc383a26b91bcb88293a
   languageName: node
   linkType: hard
 
@@ -3511,7 +3511,7 @@ __metadata:
     "@eslint/compat": ^2.0.0
     "@eslint/eslintrc": ^3.3.3
     "@eslint/js": ^9.39.2
-    "@types/node": ^20.19.27
+    "@types/node": ^24.0.0
     "@typescript-eslint/eslint-plugin": ^8.50.0
     "@typescript-eslint/parser": ^8.50.0
     "@vercel/ncc": ^0.38.4
@@ -6786,10 +6786,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 46331c7d6016bf85b3e8f20c159d62f5ae471aba1eb3dc52fff35a0259d58dcc7d592d4cc4f00c5f9243fa738a11cfa48bd20203040d4a9e6bc25e807fab7ab3
+"undici-types@npm:~7.16.0":
+  version: 7.16.0
+  resolution: "undici-types@npm:7.16.0"
+  checksum: 1ef68fc6c5bad200c8b6f17de8e5bc5cfdcadc164ba8d7208cd087cfa8583d922d8316a7fd76c9a658c22b4123d3ff847429185094484fbc65377d695c905857
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR migrates the GitHub Action from Node.js 20 to Node.js 24.

Fixes #1444

### Background

GitHub is deprecating Node.js 20 on GitHub Actions runners. According to the [GitHub changelog announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), actions using `node20` will stop working around April 2026.

### Changes

| File | Change |
|------|--------|
| `action.yml` | Updated runtime from `node20` to `node24` |
| `dev.Dockerfile` | Updated `NODE_VERSION` from `20` to `24` |
| `package.json` | Updated `@types/node` from `^20.6.0` to `^24.0.0` |
| `yarn.lock`  | Regenerated |

### Testing

- [x] `docker buildx bake validate` passes
- [x] `docker buildx bake test` passes
- [x] All existing functionality remains unchanged

