### PR TITLE
ci(e2e): scope login to push

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -119,6 +119,7 @@ jobs:
           registry: ${{ env.REGISTRY_FQDN || inputs.registry }}
           username: ${{ env.REGISTRY_USER || secrets.registry_username }}
           password: ${{ env.REGISTRY_PASSWORD || secrets.registry_password }}
+          scope: '@push'
       -
         name: Build and push
         uses: ./
@@ -131,16 +132,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY_SLUG || inputs.slug }}:master
           cache-to: type=inline
-      -
-        name: Inspect image
-        env:
-          SLUG: ${{ env.REGISTRY_SLUG || inputs.slug }}
-        run: |
-          docker pull ${SLUG}:${{ steps.meta.outputs.version }}
-          docker image inspect ${SLUG}:${{ steps.meta.outputs.version }}
-      -
-        name: Check manifest
-        env:
-          SLUG: ${{ env.REGISTRY_SLUG || inputs.slug }}
-        run: |
-          docker buildx imagetools inspect ${SLUG}:${{ steps.meta.outputs.version }} --format '{{json .}}'


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/actions/runs/26235548000/job/77207589758#step:11:317

```
--------------------
   1 |     # syntax=docker/dockerfile:1
   2 | >>> FROM --platform=$BUILDPLATFORM golang:alpine AS build
   3 |     
   4 |     ARG TARGETPLATFORM
--------------------
ERROR: failed to build: failed to solve: failed to copy: httpReadSeeker: failed open: unexpected status from GET request to https://registry-1.docker.io/v2/library/alpine/manifests/sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11: 429 Too Many Requests
toomanyrequests: You have reached your pull rate limit as '***': dckr_jti_N2ET7FEmmANT7CaMgfMLu5Rs4JQ=. You may increase the limit by upgrading. https://www.docker.com/increase-rate-limit
```