### PR TITLE
ci(e2e): limit push-scoped login to Docker Hub

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -119,7 +119,7 @@ jobs:
           registry: ${{ env.REGISTRY_FQDN || inputs.registry }}
           username: ${{ env.REGISTRY_USER || secrets.registry_username }}
           password: ${{ env.REGISTRY_PASSWORD || secrets.registry_password }}
-          scope: '@push'
+          scope: ${{ inputs.type == 'remote' && inputs.registry == '' && '@push' || '' }}
       -
         name: Build and push
         uses: ./


### PR DESCRIPTION
This restricts the e2e registry login `scope: '@push'` setting to the Docker Hub remote matrix entry.

The reusable e2e workflow now passes `@push` only when the registry input is empty and the provider is remote, which matches the Docker Hub case.

The push-scoped login avoids using Docker Hub credentials for unrelated pull operations, but other providers still need normal credentials during the build because registry cache imports and blob `HEAD` checks require pull or unscoped auth.

Relates to:

https://github.com/docker/build-push-action/actions/runs/26563668733/job/78252719035#step:11:425

```
#39 exporting attestation manifest sha256:af96fb9e850d3caddb211c35f4d595bc74c60070ab3c1a7869fd3f83ee3a58d4 done
#39 exporting manifest sha256:704536660ba4aa3fe8a278e1f51834cb255c418b141b4f1774bc228f029db242 done
#39 exporting config sha256:398eb69f6f9e6efee0a774aa918156d35b4d968e4e8e2d0d41d6474b53693b7a done
#39 exporting attestation manifest sha256:c737b87229ae1bb7ae6093f1294e13fdd9dbb36f7a8df034975f5625a560560c done
#39 exporting manifest list sha256:c6fe4d076bef300411d8132d1a439966fb56e82305a721b36a4bf81b0bfd3125
#39 exporting manifest list sha256:c6fe4d076bef300411d8132d1a439966fb56e82305a721b36a4bf81b0bfd3125 done
#39 pushing layers 0.1s done
#39 ERROR: failed to push 175142243308.dkr.ecr.us-east-2.amazonaws.com/sandbox/test-docker-action:gh-runid-26563668733: unexpected status from HEAD request to https://175142243308.dkr.ecr.us-east-2.amazonaws.com/v2/sandbox/test-docker-action/blobs/sha256:ebb190a2c061599f9c00bac77eea840af71452585443b9984a8cbcb3bb9070c7: 401 Unauthorized
------
 > importing cache manifest from 175142243308.dkr.ecr.us-east-2.amazonaws.com/sandbox/test-docker-action:master:
------
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to push 175142243308.dkr.ecr.us-east-2.amazonaws.com/sandbox/test-docker-action:gh-runid-26563668733: unexpected status from HEAD request to https://175142243308.dkr.ecr.us-east-2.amazonaws.com/v2/sandbox/test-docker-action/blobs/sha256:ebb190a2c061599f9c00bac77eea840af71452585443b9984a8cbcb3bb9070c7: 401 Unauthorized
```

https://github.com/docker/build-push-action/actions/runs/26563668733/job/78252719085#step:11:481

```
#39 exporting attestation manifest sha256:971852c5d988937385b3e11e71dd8fe41d9ef198fc82db1b02dc3e962281803f 0.0s done
#39 exporting manifest list sha256:92f63952d7a9d4f81735e15f9234b89d9672403742295add08f5d977ca1ca899 0.0s done
#39 pushing layers
#39 pushing layers 0.4s done
#39 ERROR: failed to push infradock.jfrog.io/test-ghaction/build-push-action:gh-runid-26563668733: failed to authorize: failed to fetch anonymous token: unexpected status from GET request to https://infradock.jfrog.io/artifactory/api/docker/test-ghaction/v2/token?scope=repository%3Abuild-push-action%3Apull&scope=repository%3Atest-ghaction%2Fbuild-push-action%3Apull%2Cpush&service=infradock.jfrog.io: 401 
------
 > importing cache manifest from infradock.jfrog.io/test-ghaction/build-push-action:master:
------
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to fetch anonymous token: unexpected status from GET request to https://infradock.jfrog.io/artifactory/api/docker/test-ghaction/v2/token?scope=repository%3Abuild-push-action%3Apull&scope=repository%3Atest-ghaction%2Fbuild-push-action%3Apull%2Cpush&service=infradock.jfrog.io: 401 
```

https://github.com/docker/build-push-action/actions/runs/26563668733/job/78252719088#step:11:431

```
#39 exporting attestation manifest sha256:843948c0e29977601f0a70305fc53d3237e9ea3baba3be44f3483d85e2cc3605 done
#39 exporting manifest list sha256:031996bdf1af3123ce3b03403a97faf419182822d7fe129c89b1a4a25084c1ef done
#39 pushing layers 0.0s done
#39 ERROR: failed to push localhost:8082/test-docker-action:gh-runid-26563668733: unauthorized: access to the requested resource is not authorized
------
 > importing cache manifest from localhost:8082/test-docker-action:master:
------
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to push localhost:8082/test-docker-action:gh-runid-26563668733: unauthorized: access to the requested resource is not authorized
```