### PR TITLE
feat(e2e): replace AWS_ACCESS_KEY_ID secrets with OIDC role assumption

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -22,6 +22,10 @@ on:
       slug:
         required: false
         type: string
+      aws-role-to-assume:
+        required: false
+        type: string
+        description: "IAM role ARN to assume via OIDC for ECR authentication. When set, configure-aws-credentials runs before registry login."
     secrets:
       registry_username:
         required: false
@@ -36,6 +40,9 @@ env:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +118,14 @@ jobs:
           driver-opts: |
             image=${{ matrix.buildkit_image }}
             network=host
+      -
+        name: Configure AWS credentials
+        if: inputs.aws-role-to-assume != '' && (contains(inputs.registry, '.ecr.') || inputs.registry == 'public.ecr.aws')
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          aws-region: us-east-1
+          role-session-name: gha-build-push-action-e2e-${{ github.run_id }}-${{ github.run_attempt }}
       -
         name: Login to Registry
         if: github.event_name != 'pull_request' && (inputs.type == 'remote' || env.REGISTRY_USER != '')

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: e2e
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -99,14 +100,15 @@ jobs:
       name: ${{ matrix.name }}
       registry: ${{ matrix.registry }}
       slug: ${{ matrix.slug }}
+      aws-role-to-assume: arn:aws:iam::175142243308:role/official_gha_cicd
     secrets:
       # Pass only the two secrets needed by each matrix entry.
+      # AWS ECR entries use OIDC via aws-role-to-assume instead of static keys.
       registry_username: >-
         ${{
           matrix.auth == 'dockerhub' && secrets.DOCKERHUB_USERNAME ||
           matrix.auth == 'ghcr' && secrets.GHCR_USERNAME ||
           matrix.auth == 'gitlab' && secrets.GITLAB_USERNAME ||
-          matrix.auth == 'aws' && secrets.AWS_ACCESS_KEY_ID ||
           matrix.auth == 'gar' && secrets.GAR_USERNAME ||
           matrix.auth == 'acr' && secrets.AZURE_CLIENT_ID ||
           matrix.auth == 'quay' && secrets.QUAY_USERNAME ||
@@ -118,7 +120,6 @@ jobs:
           matrix.auth == 'dockerhub' && secrets.DOCKERHUB_TOKEN ||
           matrix.auth == 'ghcr' && secrets.GHCR_PAT ||
           matrix.auth == 'gitlab' && secrets.GITLAB_TOKEN ||
-          matrix.auth == 'aws' && secrets.AWS_SECRET_ACCESS_KEY ||
           matrix.auth == 'gar' && secrets.GAR_JSON_KEY ||
           matrix.auth == 'acr' && secrets.AZURE_CLIENT_SECRET ||
           matrix.auth == 'quay' && secrets.QUAY_TOKEN ||


### PR DESCRIPTION
## Summary

Replaces static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` repository secrets with GitHub Actions OIDC role assumption for e2e tests against AWS ECR and ECR Public.

**Changes:**
- `e2e.yml`: adds `id-token: write` permission; passes `aws-role-to-assume` to `.e2e-run.yml`; removes `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` from the matrix credential expressions
- `.e2e-run.yml`: adds `aws-role-to-assume` input; adds `id-token: write` permission on `run` job; adds `configure-aws-credentials` step conditioned on ECR registry detection

**ECR detection logic:** step runs when `contains(inputs.registry, '.ecr.') || inputs.registry == 'public.ecr.aws'` — handles both private ECR (`175142243308.dkr.ecr.us-east-2.amazonaws.com`) and ECR Public (`public.ecr.aws`); correctly skips for GHCR, Docker Hub, GitLab, GAR, ACR, etc.

**Region:** `configure-aws-credentials` uses `us-east-1`. `docker/login-action` extracts region from private ECR hostnames directly, so `us-east-2` private ECR still works. ECR Public always uses `us-east-1`.

## IAM role

`arn:aws:iam::175142243308:role/official_gha_cicd` — created by `docker/infra-terraform` PR #12395.

## `configure-aws-credentials` action

Pinned: `aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a` (v4.3.1)

## ⚠️ Blocked on

1. `docker/infra-terraform-modules` PR #2931 merged and `official_gha_cicd_v1.1.0` tagged
2. `docker/infra-terraform` PR #12395 applied to sandbox account

## After this merges

Delete the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` repository secrets — they are no longer used.

## Test plan

- [ ] Merge and apply Terraform PRs first (#2931, #12395)
- [ ] Run e2e manually via `workflow_dispatch` — verify AWS ECR and ECR Public matrix entries pass
- [ ] Confirm non-AWS matrix entries (Docker Hub, GHCR, etc.) are unaffected

> *PR drafted by Claude Code.*