### PR TITLE
ci(e2e): use GITHUB_TOKEN for GHCR e2e

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -1,9 +1,6 @@
 # reusable workflow
 name: .e2e-run
 
-permissions:
-  contents: read
-
 on:
   workflow_call:
     inputs:
@@ -117,8 +114,8 @@ jobs:
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_FQDN || inputs.registry }}
-          username: ${{ env.REGISTRY_USER || secrets.registry_username }}
-          password: ${{ env.REGISTRY_PASSWORD || secrets.registry_password }}
+          username: ${{ env.REGISTRY_USER || secrets.registry_username || (inputs.registry == 'ghcr.io' && github.actor) || '' }}
+          password: ${{ env.REGISTRY_PASSWORD || secrets.registry_password || (inputs.registry == 'ghcr.io' && secrets.GITHUB_TOKEN) || '' }}
           scope: ${{ inputs.type == 'remote' && inputs.registry == '' && '@push' || '' }}
       -
         name: Build and push

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/.e2e-run.yml
+    permissions:
+      contents: read
+      packages: write # to push image to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +41,7 @@ jobs:
           -
             name: GitHub
             registry: ghcr.io
-            slug: ghcr.io/docker-ghactiontest/test
+            slug: ghcr.io/docker/build-push-action-test
             auth: ghcr
             type: remote
           -
@@ -100,11 +103,11 @@ jobs:
       registry: ${{ matrix.registry }}
       slug: ${{ matrix.slug }}
     secrets:
-      # Pass only the two secrets needed by each matrix entry.
+      # Pass only the registry-specific secrets needed by each matrix entry.
+      # GHCR uses the called workflow's GITHUB_TOKEN fallback.
       registry_username: >-
         ${{
           matrix.auth == 'dockerhub' && secrets.DOCKERHUB_USERNAME ||
-          matrix.auth == 'ghcr' && secrets.GHCR_USERNAME ||
           matrix.auth == 'gitlab' && secrets.GITLAB_USERNAME ||
           matrix.auth == 'aws' && secrets.AWS_ACCESS_KEY_ID ||
           matrix.auth == 'gar' && secrets.GAR_USERNAME ||
@@ -116,7 +119,6 @@ jobs:
       registry_password: >-
         ${{
           matrix.auth == 'dockerhub' && secrets.DOCKERHUB_TOKEN ||
-          matrix.auth == 'ghcr' && secrets.GHCR_PAT ||
           matrix.auth == 'gitlab' && secrets.GITLAB_TOKEN ||
           matrix.auth == 'aws' && secrets.AWS_SECRET_ACCESS_KEY ||
           matrix.auth == 'gar' && secrets.GAR_JSON_KEY ||

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  # rule does not apply to reusable worfklows where permissions are defined by
+  # the caller workflow and not the reusable workflow itself
+  excessive-permissions:
+    ignore:
+      - .e2e-run.yml


### PR DESCRIPTION
Updates the e2e workflow so GHCR authentication uses the workflow `GITHUB_TOKEN` instead of a stored PAT.

The caller workflow grants `packages: write` to the reusable e2e job, and the reusable workflow falls back to `github.actor` and `secrets.GITHUB_TOKEN` when the registry is `ghcr.io`.

This removes the need for a long-lived GHCR PAT while keeping the generic registry secret mapping focused on external registries.