### PR TITLE
ci(e2e): fix GitLab e2e push attestations

### DIFF
--- a/.github/workflows/.e2e-run.yml
+++ b/.github/workflows/.e2e-run.yml
@@ -61,6 +61,14 @@ jobs:
         run: |
           cat ./.github/e2e/${ID}/env >> $GITHUB_ENV
       -
+        # FIXME: Remove this once GitLab Registry accepts OCI artifact attestations
+        # whose subject points to a manifest pushed in the same build.
+        # https://github.com/docker/buildx/pull/3991
+        name: Set up GitLab env
+        if: inputs.provider == 'gitlab'
+        run: |
+          echo "BUILDX_NO_DEFAULT_OCI_ARTIFACT=true" >> "$GITHUB_ENV"
+      -
         name: Set up BuildKit config
         env:
           TYPE: ${{ inputs.type }}


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/actions/runs/30906625924/job/91983111633#step:12:406

```
#41 [auth] test1716/test:pull,push token for registry.gitlab.com
#41 DONE 0.0s

#40 exporting to image
#40 pushing layers 6.2s done
#40 pushing manifest for registry.gitlab.com/test1716/test:gh-runid-30906625924@sha256:24315ad91bbd1adaccda5231791fbb02d9f3ee36800907359411b7c7cdba1719
#40 pushing manifest for registry.gitlab.com/test1716/test:gh-runid-30906625924@sha256:24315ad91bbd1adaccda5231791fbb02d9f3ee36800907359411b7c7cdba1719 0.6s done
#40 ERROR: failed to push registry.gitlab.com/test1716/test:gh-runid-30906625924: unknown: blob unknown to registry - sha256:63adb36080a3ab14b9f318345734e94f75d748cb415475e941473177d541f726
------
 > exporting to image:
------
ERROR: failed to build: failed to solve: failed to push registry.gitlab.com/test1716/test:gh-runid-30906625924: unknown: blob unknown to registry - sha256:63adb36080a3ab14b9f318345734e94f75d748cb415475e941473177d541f726
```

This is a follow-up to https://github.com/docker/buildx/pull/3991. It applies the new Buildx compatibility escape hatch to the GitLab e2e registry runs.

The e2e reusable workflow now sets `BUILDX_NO_DEFAULT_OCI_ARTIFACT=true` only when the provider is GitLab. The workaround is documented with a `FIXME` so it can be removed once GitLab Registry accepts OCI artifact attestations whose subject references a manifest pushed in the same build.

GitLab Registry can reject pushes that use the newer OCI artifact attestation storage format and fail with `blob unknown to registry`. Setting this environment variable keeps provenance attestations enabled while making Buildx use the legacy attestation storage format for GitLab.